### PR TITLE
Luogu UI 复刻 Phase B/C/D + 同步 main + UTF-8 修复

### DIFF
--- a/frontend/src/pages/AIChat.css
+++ b/frontend/src/pages/AIChat.css
@@ -51,7 +51,7 @@
   padding: 3px 10px;
   background: var(--accent-light);
   color: var(--accent);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.2px;
@@ -702,7 +702,7 @@
 .ai-prompt-chip {
   padding: 7px 14px;
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: var(--radius);
   background: var(--bg-card);
   color: var(--text-secondary);
   font-size: 13px;

--- a/frontend/src/pages/Admin.css
+++ b/frontend/src/pages/Admin.css
@@ -1,4 +1,4 @@
-﻿.admin-page {
+.admin-page {
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -214,9 +214,7 @@
 }
 
 .stat-card:hover {
-  border-color: var(--border-hover);
-  box-shadow: var(--shadow-card);
-  transform: translateY(-2px);
+  border-color: var(--accent);
 }
 
 .stat-card:hover::before {
@@ -239,27 +237,27 @@
 }
 
 .stat-icon-wrapper.blue {
-  background: linear-gradient(135deg, var(--info-bg), rgba(59, 130, 246, 0.05));
+  background: var(--info-bg);
   color: var(--info);
 }
 
 .stat-icon-wrapper.green {
-  background: linear-gradient(135deg, var(--success-bg), rgba(34, 197, 94, 0.05));
+  background: var(--success-bg);
   color: var(--success);
 }
 
 .stat-icon-wrapper.purple {
-  background: linear-gradient(135deg, rgba(167, 139, 250, 0.15), rgba(139, 92, 246, 0.05));
-  color: #a78bfa;
+  background: var(--accent-light);
+  color: var(--accent);
 }
 
 .stat-icon-wrapper.orange {
-  background: linear-gradient(135deg, var(--warning-bg), rgba(245, 158, 11, 0.05));
+  background: var(--warning-bg);
   color: var(--warning);
 }
 
 .stat-icon-wrapper.red {
-  background: linear-gradient(135deg, var(--error-bg), rgba(239, 68, 68, 0.05));
+  background: var(--error-bg);
   color: var(--error);
 }
 
@@ -271,10 +269,7 @@
   font-size: 32px;
   font-weight: 700;
   line-height: 1.1;
-  background: linear-gradient(135deg, var(--text-primary), var(--text-secondary));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
 }
 
 .stat-label {
@@ -328,7 +323,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -690,7 +684,6 @@
 .testcase-io label {
   font-size: 11px;
   color: var(--text-muted);
-  text-transform: uppercase;
 }
 
 .testcase-io pre {
@@ -1478,7 +1471,7 @@
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
   overflow: hidden;
 }
 
@@ -1554,7 +1547,7 @@
 }
 
 .visibility-toggle.private {
-  color: var(--text-muted, #888);
+  color: var(--text-muted);
   background: rgba(136, 136, 136, 0.1);
 }
 
@@ -1642,7 +1635,6 @@
   font-weight: 600;
   border: 1px solid;
   border-radius: 10px;
-  text-transform: capitalize;
 }
 
 .link {
@@ -1677,7 +1669,7 @@
   display: inline-flex;
   align-items: center;
   padding: 4px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 500;
   background: var(--bg-tertiary);
@@ -1818,7 +1810,7 @@
   left: 0;
   right: 0;
   height: 2px;
-  background: linear-gradient(90deg, var(--accent), transparent);
+  background: var(--accent);
 }
 
 .admin-sidebar-title {

--- a/frontend/src/pages/Blogs.css
+++ b/frontend/src/pages/Blogs.css
@@ -1,4 +1,4 @@
-﻿.blogs-page {
+.blogs-page {
   max-width: 800px;
   margin: 0 auto;
   padding: 24px;
@@ -27,8 +27,8 @@
 .sort-tabs {
   display: flex;
   gap: 4px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 2px;
 }
@@ -37,7 +37,7 @@
   padding: 4px 12px;
   background: transparent;
   border: none;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   cursor: pointer;
   border-radius: 6px;
   font-size: 13px;
@@ -59,8 +59,8 @@
   flex-direction: column;
   gap: 10px;
   padding: 16px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   text-decoration: none;
   color: inherit;
@@ -69,7 +69,6 @@
 
 .blog-card:hover {
   border-color: var(--accent);
-  transform: translateY(-1px);
 }
 
 .blog-card-header {
@@ -111,7 +110,7 @@
 }
 
 .blog-date {
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .blog-title {
@@ -138,7 +137,7 @@
   display: flex;
   gap: 16px;
   font-size: 12px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .blog-stats span {
@@ -158,22 +157,22 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   text-decoration: none;
   font-size: 13px;
   margin-bottom: 16px;
 }
 
 .blog-article {
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   overflow: hidden;
 }
 
 .article-header {
   padding: 24px;
-  border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-bottom: 1px solid var(--border);
 }
 
 .article-header h1 {
@@ -186,7 +185,7 @@
   align-items: center;
   gap: 8px;
   font-size: 13px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .article-author {
@@ -196,7 +195,7 @@
 }
 
 .meta-sep {
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .draft-badge {
@@ -236,7 +235,7 @@
 
 .article-footer {
   padding: 16px 24px;
-  border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-top: 1px solid var(--border);
 }
 
 .article-actions {
@@ -251,7 +250,7 @@
   gap: 6px;
   background: transparent;
   border: none;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 14px;
   padding: 4px 8px;
@@ -276,8 +275,8 @@
 /* Comments */
 .comments-section {
   margin-top: 24px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   padding: 20px;
 }
@@ -296,8 +295,8 @@
 
 .comment-form textarea {
   padding: 10px 12px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   color: inherit;
   outline: none;
@@ -340,7 +339,7 @@
 
 .comment-time {
   font-size: 11px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .comment-text {
@@ -351,7 +350,7 @@
 .empty-text {
   text-align: center;
   padding: 20px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   font-size: 13px;
 }
 
@@ -383,8 +382,8 @@
 .blog-editor-form input,
 .blog-editor-form textarea {
   padding: 10px 12px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   color: inherit;
   outline: none;
@@ -405,7 +404,7 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .empty-state p {

--- a/frontend/src/pages/ContestDetail.css
+++ b/frontend/src/pages/ContestDetail.css
@@ -83,7 +83,7 @@
 }
 
 .nav-problem-btn.active {
-  background: var(--accent-light, rgba(108, 140, 255, 0.12));
+  background: var(--accent-light);
   color: var(--accent);
 }
 
@@ -226,7 +226,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -283,7 +283,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -329,7 +328,7 @@
   width: 32px;
   height: 32px;
   border-radius: var(--radius);
-  background: var(--accent-light, rgba(108, 140, 255, 0.12));
+  background: var(--accent-light);
   color: var(--accent);
   font-weight: 700;
   font-size: 14px;
@@ -501,7 +500,7 @@
 }
 
 .cell-attempted {
-  background: rgba(108, 140, 255, 0.08);
+  background: var(--accent-light);
   color: var(--accent);
 }
 
@@ -575,7 +574,7 @@
   width: 28px;
   height: 28px;
   border-radius: var(--radius);
-  background: var(--accent-light, rgba(108, 140, 255, 0.12));
+  background: var(--accent-light);
   color: var(--accent);
   font-weight: 700;
   font-size: 13px;
@@ -754,7 +753,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 

--- a/frontend/src/pages/Contests.css
+++ b/frontend/src/pages/Contests.css
@@ -41,7 +41,7 @@
   border: 1px solid var(--border);
   background: var(--bg-card);
   color: var(--text-secondary);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;

--- a/frontend/src/pages/CreateContest.css
+++ b/frontend/src/pages/CreateContest.css
@@ -8,7 +8,7 @@
   background: var(--bg-secondary);
   border-radius: 12px;
   padding: 24px;
-  border: 1px solid var(--border-color, var(--border));
+  border: 1px solid var(--border);
 }
 
 .create-contest-header {
@@ -40,7 +40,7 @@
 .contest-form .form-textarea {
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid var(--border-color, var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-primary);
   color: var(--text-primary);

--- a/frontend/src/pages/CreateProblemList.css
+++ b/frontend/src/pages/CreateProblemList.css
@@ -8,7 +8,7 @@
   background: var(--bg-secondary);
   border-radius: 12px;
   padding: 24px;
-  border: 1px solid var(--border-color, var(--border));
+  border: 1px solid var(--border);
 }
 
 .create-list-header {
@@ -40,7 +40,7 @@
 .list-form .form-textarea {
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid var(--border-color, var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-primary);
   color: var(--text-primary);

--- a/frontend/src/pages/DiscussionDetail.css
+++ b/frontend/src/pages/DiscussionDetail.css
@@ -70,7 +70,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -97,7 +97,7 @@
   padding: 3px 10px;
   background: var(--warning-bg);
   color: var(--warning);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }

--- a/frontend/src/pages/Discussions.css
+++ b/frontend/src/pages/Discussions.css
@@ -36,7 +36,7 @@
   padding: 4px 12px;
   background: var(--accent-light);
   color: var(--accent);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 13px;
   font-weight: 500;
 }
@@ -78,7 +78,7 @@
   border: 1px solid var(--border);
   background: var(--bg-card);
   color: var(--text-secondary);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
@@ -175,7 +175,7 @@
   padding: 2px 8px;
   background: var(--warning-bg);
   color: var(--warning);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 11px;
   font-weight: 600;
   flex-shrink: 0;
@@ -185,7 +185,7 @@
   display: inline-flex;
   align-items: center;
   padding: 2px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
   flex-shrink: 0;

--- a/frontend/src/pages/Favorites.css
+++ b/frontend/src/pages/Favorites.css
@@ -75,7 +75,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -120,7 +119,7 @@
   display: inline-flex;
   align-items: center;
   padding: 4px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 500;
   background: var(--bg-tertiary);

--- a/frontend/src/pages/FollowList.css
+++ b/frontend/src/pages/FollowList.css
@@ -1,4 +1,4 @@
-﻿.follow-list-page {
+.follow-list-page {
   max-width: 900px;
   margin: 0 auto;
   padding: 24px;
@@ -30,8 +30,8 @@
   align-items: center;
   gap: 12px;
   padding: 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 10px;
   text-decoration: none;
   color: inherit;
@@ -73,7 +73,7 @@
 
 .follow-bio {
   font-size: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   margin-top: 2px;
   white-space: nowrap;
   overflow: hidden;
@@ -83,5 +83,5 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }

--- a/frontend/src/pages/GlobalDiscussions.css
+++ b/frontend/src/pages/GlobalDiscussions.css
@@ -120,7 +120,7 @@
   padding: 2px 8px;
   background: var(--warning-bg);
   color: var(--warning);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 11px;
   font-weight: 600;
   flex-shrink: 0;
@@ -130,7 +130,7 @@
   display: inline-flex;
   align-items: center;
   padding: 2px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
   flex-shrink: 0;

--- a/frontend/src/pages/GlobalSolutions.css
+++ b/frontend/src/pages/GlobalSolutions.css
@@ -130,7 +130,7 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 11px;
   font-weight: 600;
   background: var(--accent-light);

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -1,30 +1,30 @@
 .home-page {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
-/* Hero Section */
+/* ── Hero ── */
 .home-hero {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
-  padding: 32px;
-  background: var(--accent-light);
-  border: 1px solid var(--accent);
+  padding: 20px 24px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: var(--radius-lg);
 }
 
 .home-hero-left {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .home-title {
-  font-size: 28px;
-  font-weight: 800;
+  font-size: 22px;
+  font-weight: 700;
   color: var(--text-primary);
   margin: 0;
 }
@@ -33,20 +33,20 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 14px;
+  font-size: 13px;
   color: var(--text-secondary);
 }
 
 .home-welcome {
-  font-size: 15px;
-  color: var(--text-primary);
-  font-weight: 500;
+  font-size: 13px;
+  color: var(--text-secondary);
 }
 
 .home-stats-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 10px;
+  gap: 8px;
+  min-width: 320px;
 }
 
 .home-stat-card {
@@ -54,19 +54,19 @@
   align-items: center;
   gap: 8px;
   padding: 10px 14px;
-  background: var(--bg-card);
+  background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   text-decoration: none;
   color: var(--text-primary);
   font-size: 13px;
   font-weight: 500;
-  transition: all var(--transition, 0.2s);
+  transition: all var(--transition, 0.15s);
 }
 
 .home-stat-card:hover {
   border-color: var(--accent);
-  background: var(--bg-secondary);
+  color: var(--accent);
 }
 
 .home-stat-card svg:first-child {
@@ -81,17 +81,17 @@
   color: var(--text-muted);
 }
 
-/* Announcement */
+/* ── Announcement ── */
 .home-announcement {
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   background: var(--accent-light);
-  border: 1px solid var(--accent);
+  border-left: 3px solid var(--accent);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.6;
 }
 
@@ -116,33 +116,35 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   border: none;
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
-  border-radius: 4px;
-  transition: all var(--transition, 0.2s);
+  border-radius: var(--radius);
+  transition: all var(--transition, 0.15s);
 }
 
 .home-announcement .announcement-close:hover {
-  background: var(--bg-tertiary, rgba(0,0,0,0.05));
+  background: var(--bg-tertiary);
   color: var(--text-primary);
 }
 
-/* Hitokoto */
+/* ── Hitokoto (horizontal bar like Luogu) ── */
 .home-hitokoto {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 16px 20px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   cursor: pointer;
-  transition: all var(--transition, 0.2s);
-  position: relative;
+  transition: all var(--transition, 0.15s);
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
 }
 
 .home-hitokoto:hover {
@@ -150,45 +152,48 @@
 }
 
 .hitokoto-icon {
-  color: var(--text-muted);
-  opacity: 0.5;
+  color: var(--accent);
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 
 .hitokoto-text {
-  font-size: 15px;
-  line-height: 1.7;
+  flex: 1;
+  font-size: 13px;
+  line-height: 1.6;
   color: var(--text-primary);
   font-style: italic;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hitokoto-from {
+  flex-shrink: 0;
   font-size: 12px;
   color: var(--text-muted);
-  text-align: right;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hitokoto-error .hitokoto-text {
   font-style: normal;
   color: var(--text-secondary);
   font-size: 13px;
-}
-
-/* Content Grid */
-.home-content-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
+  white-space: normal;
 }
 
 /* ── Recommendation Section ── */
 .home-recommend-section {
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg, 12px);
-  padding: 18px;
+  border-radius: var(--radius-lg);
+  padding: 14px 18px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
 }
 
 .home-recommend-header {
@@ -197,6 +202,8 @@
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
 }
 
 .recommend-title-block {
@@ -206,13 +213,27 @@
 }
 
 .recommend-icon {
-  color: var(--accent, #f59e0b);
+  color: var(--accent);
 }
 
 .home-recommend-header h2 {
   margin: 0;
-  font-size: 16px;
-  font-weight: 700;
+  font-size: 15px;
+  font-weight: 600;
+  position: relative;
+  padding-left: 10px;
+}
+
+.home-recommend-header h2::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 14px;
+  background: var(--accent);
+  border-radius: 2px;
 }
 
 .recommend-subtitle {
@@ -225,25 +246,24 @@
 .recommend-cards {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 12px;
+  gap: 10px;
 }
 
 .recommend-card {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px 14px;
-  background: var(--bg-secondary, var(--bg-tertiary));
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--bg-tertiary);
   border: 1px solid var(--border);
-  border-radius: var(--radius, 8px);
+  border-radius: var(--radius);
   text-decoration: none;
   color: var(--text-primary);
-  transition: all var(--transition, 0.2s);
+  transition: all var(--transition, 0.15s);
 }
 
 .recommend-card:hover {
   border-color: var(--accent);
-  box-shadow: var(--shadow);
 }
 
 .recommend-card-header {
@@ -262,7 +282,7 @@
   margin-left: auto;
   padding: 1px 6px;
   background: var(--accent);
-  color: white;
+  color: #fff;
   border-radius: var(--radius);
   font-size: 11px;
   font-weight: 700;
@@ -281,7 +301,7 @@
 
 .recommend-card-reason {
   font-size: 11px;
-  color: var(--text-muted, var(--text-secondary));
+  color: var(--text-muted);
   font-style: italic;
 }
 
@@ -292,11 +312,11 @@
 }
 
 .recommend-tag {
-  font-size: 10px;
+  font-size: 11px;
   color: var(--text-secondary);
-  background: var(--bg-tertiary, rgba(0,0,0,0.05));
+  background: var(--bg-secondary);
   padding: 1px 6px;
-  border-radius: 10px;
+  border-radius: var(--radius);
 }
 
 @media (max-width: 600px) {
@@ -305,10 +325,17 @@
   }
 }
 
+/* ── Content Cards ── */
+.home-content-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
 .home-card {
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg, 12px);
+  border-radius: var(--radius-lg);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -318,18 +345,33 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 18px;
+  padding: 10px 16px;
   border-bottom: 1px solid var(--border);
+  background: var(--bg-tertiary);
 }
 
 .home-card-header h2 {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   margin: 0;
   color: var(--text-primary);
+  position: relative;
+  padding-left: 10px;
+}
+
+.home-card-header h2::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 14px;
+  background: var(--accent);
+  border-radius: 2px;
 }
 
 .home-card-header h2 svg {
@@ -366,20 +408,22 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 18px;
+  padding: 8px 16px;
   text-decoration: none;
   color: var(--text-primary);
-  transition: background var(--transition, 0.2s);
+  transition: background var(--transition, 0.15s);
   gap: 12px;
+  border-left: 3px solid transparent;
 }
 
 .home-item:hover {
-  background: var(--bg-secondary);
+  background: var(--bg-tertiary);
+  border-left-color: var(--accent);
 }
 
 .home-item-title {
   flex: 1;
-  font-size: 14px;
+  font-size: 13px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -402,7 +446,7 @@
   flex-shrink: 0;
   font-size: 11px;
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius);
   font-weight: 500;
 }
 
@@ -421,23 +465,24 @@
   color: var(--text-muted);
 }
 
-/* Responsive */
+/* ── Responsive ── */
 @media (max-width: 768px) {
   .home-hero {
     flex-direction: column;
-    padding: 20px;
-    text-align: center;
+    align-items: flex-start;
+    padding: 16px;
   }
 
-  .home-hero-left {
-    align-items: center;
+  .home-stats-grid {
+    width: 100%;
+    min-width: 0;
   }
 
   .home-content-grid {
     grid-template-columns: 1fr;
   }
 
-  .home-stats-grid {
-    width: 100%;
+  .hitokoto-from {
+    display: none;
   }
 }

--- a/frontend/src/pages/Login.css
+++ b/frontend/src/pages/Login.css
@@ -16,7 +16,7 @@
   justify-content: center;
   width: 80px;
   height: 80px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   background: var(--accent-light);
   color: var(--accent);
   margin-bottom: 24px;
@@ -142,7 +142,7 @@
 .auth-form input:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(108, 140, 255, 0.15);
+  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.15);
 }
 
 .form-error {

--- a/frontend/src/pages/Messages.css
+++ b/frontend/src/pages/Messages.css
@@ -1,4 +1,4 @@
-﻿.messages-page {
+.messages-page {
   height: calc(100vh - 60px);
   padding: 16px;
 }
@@ -10,8 +10,8 @@
   display: grid;
   grid-template-columns: 320px 1fr;
   gap: 12px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   overflow: hidden;
 }
@@ -29,7 +29,7 @@
   align-items: center;
   gap: 10px;
   padding: 14px 16px;
-  border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-bottom: 1px solid var(--border);
   font-weight: 600;
 }
 
@@ -99,7 +99,7 @@
 
 .conv-preview {
   font-size: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -139,8 +139,8 @@
 .message-bubble {
   max-width: 70%;
   padding: 10px 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.06));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
 }
 
@@ -156,7 +156,7 @@
 
 .message-time {
   font-size: 11px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   margin-top: 4px;
   text-align: right;
 }
@@ -165,14 +165,14 @@
   display: flex;
   gap: 8px;
   padding: 12px 16px;
-  border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-top: 1px solid var(--border);
 }
 
 .message-input-form input {
   flex: 1;
   padding: 10px 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.06));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   color: inherit;
   outline: none;
@@ -189,7 +189,7 @@
   align-items: center;
   justify-content: center;
   gap: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   font-size: 13px;
 }
 
@@ -223,7 +223,7 @@
   padding: 0;
   border: none;
   background: transparent;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   cursor: pointer;
   border-radius: 6px;
   transition: all 0.15s;
@@ -239,7 +239,7 @@
   align-self: center;
   padding: 8px 18px;
   background: var(--bg-tertiary, rgba(255,255,255,0.04));
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   border: 1px solid var(--border);
   border-radius: 16px;
   font-size: 12px;
@@ -278,7 +278,7 @@
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 12px 40px rgba(0,0,0,0.4);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 }
 
 .msg-modal-header {
@@ -316,7 +316,7 @@
 }
 
 .msg-search-icon {
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 
@@ -341,7 +341,7 @@
 .msg-search-empty {
   padding: 24px 8px;
   text-align: center;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   font-size: 13px;
 }
 
@@ -397,7 +397,6 @@
   border-radius: 8px;
   background: var(--accent);
   color: #fff;
-  text-transform: uppercase;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/pages/Notifications.css
+++ b/frontend/src/pages/Notifications.css
@@ -1,4 +1,4 @@
-﻿.notifications-page {
+.notifications-page {
   max-width: 800px;
   margin: 0 auto;
   padding: 24px;
@@ -28,10 +28,10 @@
 
 .type-tab {
   padding: 6px 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 999px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 13px;
   transition: all 0.15s;
@@ -58,8 +58,8 @@
   align-items: flex-start;
   gap: 12px;
   padding: 14px 16px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 10px;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
@@ -95,13 +95,13 @@
 
 .notification-desc {
   font-size: 13px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   margin-top: 4px;
 }
 
 .notification-time {
   font-size: 12px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   margin-top: 6px;
 }
 
@@ -114,7 +114,7 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .empty-state p {

--- a/frontend/src/pages/ProblemDetail.css
+++ b/frontend/src/pages/ProblemDetail.css
@@ -146,8 +146,8 @@
 .difficulty-badge[data-difficulty="普及"]     { color: var(--diff-mid); border-color: var(--diff-mid); background: color-mix(in srgb, var(--diff-mid) 12%, transparent); }
 .difficulty-badge[data-difficulty="提高"]     { color: var(--diff-hard); border-color: var(--diff-hard); background: color-mix(in srgb, var(--diff-hard) 12%, transparent); }
 .difficulty-badge[data-difficulty="提高+"]    { color: var(--diff-hard-plus); border-color: var(--diff-hard-plus); background: color-mix(in srgb, var(--diff-hard-plus) 12%, transparent); }
-.difficulty-badge[data-difficulty="省�?"]    { color: var(--diff-province); border-color: var(--diff-province); background: color-mix(in srgb, var(--diff-province) 12%, transparent); }
-.difficulty-badge[data-difficulty="省�?]     { color: var(--diff-province-plus); border-color: var(--diff-province-plus); background: color-mix(in srgb, var(--diff-province-plus) 12%, transparent); }
+.difficulty-badge[data-difficulty="省选-"]    { color: var(--diff-province); border-color: var(--diff-province); background: color-mix(in srgb, var(--diff-province) 12%, transparent); }
+.difficulty-badge[data-difficulty="省选"]     { color: var(--diff-province-plus); border-color: var(--diff-province-plus); background: color-mix(in srgb, var(--diff-province-plus) 12%, transparent); }
 .difficulty-badge[data-difficulty="NOI"]      { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }
 .difficulty-badge[data-difficulty="NOI+"]     { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }
 .difficulty-badge[data-difficulty="CTSC"]     { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }

--- a/frontend/src/pages/ProblemDetail.css
+++ b/frontend/src/pages/ProblemDetail.css
@@ -132,10 +132,25 @@
 .difficulty-badge {
   font-size: 13px;
   font-weight: 600;
-  padding: 6px 16px;
-  border-radius: 20px;
+  padding: 4px 12px;
+  border-radius: var(--radius);
   border: 1px solid;
+  display: inline-flex;
+  align-items: center;
 }
+
+/* Luogu-style difficulty badge backgrounds */
+.difficulty-badge[data-difficulty="暂无难度"] { color: var(--diff-none); border-color: var(--diff-none); background: color-mix(in srgb, var(--diff-none) 12%, transparent); }
+.difficulty-badge[data-difficulty="入门"]     { color: var(--diff-easy); border-color: var(--diff-easy); background: color-mix(in srgb, var(--diff-easy) 12%, transparent); }
+.difficulty-badge[data-difficulty="普及-"]    { color: var(--diff-easy-mid); border-color: var(--diff-easy-mid); background: color-mix(in srgb, var(--diff-easy-mid) 12%, transparent); }
+.difficulty-badge[data-difficulty="普及"]     { color: var(--diff-mid); border-color: var(--diff-mid); background: color-mix(in srgb, var(--diff-mid) 12%, transparent); }
+.difficulty-badge[data-difficulty="提高"]     { color: var(--diff-hard); border-color: var(--diff-hard); background: color-mix(in srgb, var(--diff-hard) 12%, transparent); }
+.difficulty-badge[data-difficulty="提高+"]    { color: var(--diff-hard-plus); border-color: var(--diff-hard-plus); background: color-mix(in srgb, var(--diff-hard-plus) 12%, transparent); }
+.difficulty-badge[data-difficulty="省�?"]    { color: var(--diff-province); border-color: var(--diff-province); background: color-mix(in srgb, var(--diff-province) 12%, transparent); }
+.difficulty-badge[data-difficulty="省�?]     { color: var(--diff-province-plus); border-color: var(--diff-province-plus); background: color-mix(in srgb, var(--diff-province-plus) 12%, transparent); }
+.difficulty-badge[data-difficulty="NOI"]      { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }
+.difficulty-badge[data-difficulty="NOI+"]     { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }
+.difficulty-badge[data-difficulty="CTSC"]     { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }
 
 .favorite-btn {
   display: flex;
@@ -185,7 +200,7 @@
 .action-btn-outline:hover {
   border-color: var(--accent);
   color: var(--accent);
-  background: var(--accent-light, rgba(108, 140, 255, 0.08));
+  background: var(--accent-light);
 }
 
 .problem-meta {
@@ -200,11 +215,11 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
+  font-size: 12px;
   color: var(--text-secondary);
   background: var(--bg-tertiary);
-  padding: 4px 10px;
-  border-radius: 20px;
+  padding: 3px 10px;
+  border-radius: var(--radius);
 }
 
 .meta-item.pass-rate {
@@ -294,8 +309,6 @@
   color: var(--text-muted);
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
 }
 
 .sample-box pre {
@@ -573,7 +586,7 @@
 
 .filter-btn.active {
   color: var(--accent);
-  background: var(--accent-light, rgba(108, 140, 255, 0.08));
+  background: var(--accent-light);
   border-color: var(--accent);
 }
 
@@ -687,7 +700,7 @@
 
 .inline-card:hover {
   border-color: var(--accent);
-  background: var(--accent-light, rgba(108, 140, 255, 0.04));
+  background: var(--accent-light);
 }
 
 .inline-card.pinned {
@@ -771,8 +784,8 @@
   font-size: 11px;
   font-weight: 600;
   color: var(--accent);
-  background: var(--accent-light, rgba(108, 140, 255, 0.08));
-  border-radius: 4px;
+  background: var(--accent-light);
+  border-radius: var(--radius);
   flex-shrink: 0;
 }
 
@@ -783,7 +796,7 @@
   padding: 2px 8px;
   font-size: 11px;
   font-weight: 600;
-  border-radius: 4px;
+  border-radius: var(--radius);
   flex-shrink: 0;
 }
 

--- a/frontend/src/pages/ProblemDetail.tsx
+++ b/frontend/src/pages/ProblemDetail.tsx
@@ -13,7 +13,7 @@ import { useThemeStore } from '../store/theme';
 import { useToastStore } from '../store/toast';
 import StatusBadge from '../components/StatusBadge';
 import { Send, Clock, MemoryStick, ChevronLeft, ChevronRight, Tag, Heart, CheckCircle, XCircle, AlertCircle, Users, BookOpen, MessageSquare, ThumbsUp, Eye, Plus, X, Sparkles, Flag } from 'lucide-react';
-import { LANGUAGES, LANGUAGE_TEMPLATES, DIFFICULTY_COLORS } from '../constants';
+import { LANGUAGES, LANGUAGE_TEMPLATES } from '../constants';
 import RatingBadge from '../components/RatingBadge';
 import { renderMarkdown } from '../utils/markdown';
 import { t } from '../i18n';
@@ -629,7 +629,7 @@ export default function ProblemDetail() {
             ) : (
               <div
                 className="difficulty-badge"
-                style={{ background: `${DIFFICULTY_COLORS[problem.difficulty]}20`, color: DIFFICULTY_COLORS[problem.difficulty], borderColor: DIFFICULTY_COLORS[problem.difficulty] }}
+                data-difficulty={problem.difficulty || ''}
               >
                 {problem.difficulty}
               </div>

--- a/frontend/src/pages/ProblemList.css
+++ b/frontend/src/pages/ProblemList.css
@@ -1,7 +1,7 @@
 .problem-list-page {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
 .page-header {
@@ -12,59 +12,25 @@
 }
 
 .page-header h1 {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 700;
+  position: relative;
+  padding-left: 12px;
 }
 
-.announcement-banner {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 12px 16px;
-  background: var(--accent-light);
-  border: 1px solid var(--accent);
-  border-radius: var(--radius);
-  color: var(--text-primary);
-  font-size: 14px;
-  line-height: 1.6;
+.page-header h1::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 18px;
+  background: var(--accent);
+  border-radius: 2px;
 }
 
-.announcement-icon {
-  flex-shrink: 0;
-  color: var(--accent);
-  margin-top: 2px;
-}
-
-.announcement-content {
-  flex: 1;
-  min-width: 0;
-}
-
-.announcement-content a {
-  color: var(--accent);
-  text-decoration: underline;
-}
-
-.announcement-close {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  border-radius: 4px;
-  transition: all var(--transition);
-}
-
-.announcement-close:hover {
-  background: var(--bg-tertiary, rgba(0,0,0,0.05));
-  color: var(--text-primary);
-}
-
+/* ── Search ── */
 .search-bar {
   display: flex;
   align-items: center;
@@ -72,9 +38,10 @@
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 8px 14px;
+  padding: 6px 12px;
   width: 300px;
   transition: border-color var(--transition);
+  color: var(--text-muted);
 }
 
 .search-bar:focus-within {
@@ -86,7 +53,7 @@
   border: none;
   outline: none;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
   width: 100%;
 }
 
@@ -94,13 +61,19 @@
   color: var(--text-muted);
 }
 
+/* ── Filters ── */
 .filters {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 12px 16px;
 }
 
-.difficulty-filter {
+.difficulty-filter,
+.tag-filter {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -110,14 +83,33 @@
 
 .filter-label {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 40px;
+}
+
+.filter-select {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 5px 10px;
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+  transition: border-color var(--transition);
+}
+
+.filter-select:focus,
+.filter-select:hover {
+  border-color: var(--accent);
 }
 
 .difficulty-chip {
   display: inline-flex;
   align-items: center;
-  padding: 4px 12px;
-  border-radius: 20px;
+  padding: 3px 10px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
   background: var(--bg-tertiary);
@@ -134,19 +126,11 @@
   border: 1px solid;
 }
 
-.tag-filter {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--text-secondary);
-  flex-wrap: wrap;
-}
-
 .tag-chip {
   display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
-  border-radius: 20px;
+  padding: 3px 10px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 500;
   background: var(--bg-tertiary);
@@ -169,19 +153,19 @@
 }
 
 .tag-chip.small {
-  padding: 2px 8px;
+  padding: 1px 6px;
   font-size: 11px;
 }
 
 .clear-filters-btn {
   align-self: flex-start;
-  padding: 6px 16px;
-  font-size: 13px;
+  padding: 5px 12px;
+  font-size: 12px;
   font-weight: 500;
   background: transparent;
   color: var(--accent);
   border: 1px solid var(--accent);
-  border-radius: 20px;
+  border-radius: var(--radius);
   cursor: pointer;
   transition: all var(--transition);
 }
@@ -190,17 +174,19 @@
   background: var(--accent-light);
 }
 
+/* ── Problem Table ── */
 .problem-table {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
+  overflow: hidden;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
 
 .problem-table-header {
   display: grid;
-  grid-template-columns: 36px 50px 1fr 80px 160px 70px 60px 140px;
+  grid-template-columns: 36px 50px 1fr 80px 160px 70px 90px 140px;
   gap: 6px;
   align-items: center;
   padding: 10px 14px;
@@ -208,25 +194,49 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border);
+  min-width: 800px;
 }
 
 .problem-row {
   display: grid;
-  grid-template-columns: 36px 50px 1fr 80px 160px 70px 60px 140px;
+  grid-template-columns: 36px 50px 1fr 80px 160px 70px 90px 140px;
   gap: 6px;
   align-items: center;
-  padding: 12px 14px;
-  border-top: 1px solid var(--border);
-  transition: all var(--transition);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  transition: background var(--transition);
   text-decoration: none;
   color: var(--text-primary);
+  border-left: 3px solid transparent;
+  min-width: 800px;
+  position: relative;
+}
+
+.problem-row:last-child {
+  border-bottom: none;
 }
 
 .problem-row:hover {
   background: var(--bg-tertiary);
 }
+
+/* Luogu-style left color bar by difficulty */
+.problem-row[data-difficulty="暂无难度"] { border-left-color: var(--diff-none); }
+.problem-row[data-difficulty="入门"]     { border-left-color: var(--diff-easy); }
+.problem-row[data-difficulty="普及-"]    { border-left-color: var(--diff-easy-mid); }
+.problem-row[data-difficulty="普及"]     { border-left-color: var(--diff-mid); }
+.problem-row[data-difficulty="提高"]     { border-left-color: var(--diff-hard); }
+.problem-row[data-difficulty="提高+"]    { border-left-color: var(--diff-hard-plus); }
+.problem-row[data-difficulty="省选-"]    { border-left-color: var(--diff-province); }
+.problem-row[data-difficulty="省选"]     { border-left-color: var(--diff-province-plus); }
+.problem-row[data-difficulty="NOI"]      { border-left-color: var(--diff-noi); }
+.problem-row[data-difficulty="NOI+"]     { border-left-color: var(--diff-noi); }
+.problem-row[data-difficulty="CTSC"]     { border-left-color: var(--diff-noi); }
+/* Legacy aliases */
+.problem-row[data-difficulty="Easy"]     { border-left-color: var(--diff-mid); }
+.problem-row[data-difficulty="Medium"]   { border-left-color: var(--diff-hard); }
+.problem-row[data-difficulty="Hard"]     { border-left-color: var(--diff-easy); }
 
 .problem-row.accepted {
   background: var(--success-bg);
@@ -251,8 +261,8 @@
 }
 
 .status-icon {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
 }
 
 .status-icon.accepted {
@@ -265,26 +275,30 @@
 
 .col-id {
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .col-title {
   font-weight: 500;
-  font-size: 15px;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
 }
 
+.col-title:hover {
+  color: var(--accent);
+}
+
 .col-difficulty {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
 }
 
 .col-tags {
   display: flex;
-  gap: 6px;
+  gap: 4px;
   flex-wrap: wrap;
   overflow: hidden;
   min-width: 0;
@@ -297,37 +311,65 @@
 }
 
 .col-rate {
-  text-align: center;
-  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
   font-weight: 600;
 }
 
-.col-rate.high {
-  color: var(--success);
+.pass-rate-bar {
+  flex: 1;
+  height: 6px;
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+  overflow: hidden;
+  min-width: 30px;
 }
 
-.col-rate.medium {
-  color: var(--warning);
+.pass-rate-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s;
 }
 
-.col-rate.low {
-  color: var(--error);
+.pass-rate-fill.high {
+  background: var(--success);
 }
+
+.pass-rate-fill.medium {
+  background: var(--warning);
+}
+
+.pass-rate-fill.low {
+  background: var(--error);
+}
+
+.pass-rate-text {
+  flex-shrink: 0;
+  min-width: 32px;
+  text-align: right;
+}
+
+.pass-rate-text.high   { color: var(--success); }
+.pass-rate-text.medium { color: var(--warning); }
+.pass-rate-text.low    { color: var(--error); }
 
 .col-limit {
   display: flex;
-  gap: 12px;
+  gap: 10px;
   justify-content: flex-end;
 }
 
 .limit-item {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 12px;
+  gap: 3px;
+  font-size: 11px;
   color: var(--text-muted);
 }
 
+/* ── Pagination ── */
 .pagination {
   display: flex;
   align-items: center;
@@ -337,22 +379,23 @@
 }
 
 .page-info {
-  font-size: 14px;
+  font-size: 13px;
   color: var(--text-secondary);
 }
 
+/* ── Loading / Empty ── */
 .loading-container {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 48px;
-  gap: 16px;
+  gap: 12px;
 }
 
 .loading-spinner {
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   border: 3px solid var(--border);
   border-top-color: var(--accent);
   border-radius: 50%;
@@ -369,9 +412,10 @@
   text-align: center;
   padding: 48px;
   color: var(--text-secondary);
-  font-size: 16px;
+  font-size: 14px;
 }
 
+/* ── Responsive ── */
 @media (max-width: 768px) {
   .page-header {
     flex-direction: column;
@@ -380,11 +424,6 @@
 
   .search-bar {
     width: 100%;
-  }
-
-  .filters {
-    flex-direction: column;
-    gap: 8px;
   }
 
   .problem-table-header,

--- a/frontend/src/pages/ProblemList.tsx
+++ b/frontend/src/pages/ProblemList.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuthStore } from '../store/auth';
 import { Search, Tag, Clock, MemoryStick, Filter, CheckCircle, AlertCircle } from 'lucide-react';
-import { DIFFICULTY_COLORS } from '../constants';
+import { DIFFICULTY_COLORS, DIFFICULTIES } from '../constants';
 import RatingBadge from '../components/RatingBadge';
 import { t } from '../i18n';
 import { useToastStore } from '../store/toast';
@@ -143,9 +143,9 @@ export default function ProblemList() {
             onChange={(e) => { setSelectedDifficulty(e.target.value); setPage(1); }}
           >
             <option value="">{t('problemList.allDifficulty')}</option>
-            <option value="Easy">{t('problemList.easy')}</option>
-            <option value="Medium">{t('problemList.medium')}</option>
-            <option value="Hard">{t('problemList.hard')}</option>
+            {DIFFICULTIES.map((d) => (
+              <option key={d} value={d}>{d}</option>
+            ))}
           </select>
         </div>
 
@@ -203,11 +203,16 @@ export default function ProblemList() {
           {problems.map((problem, index) => {
             const status = getProblemStatus(problem.id);
             const displayId = (pagination.page - 1) * pagination.pageSize + index + 1;
+            const rateLevel = problem.pass_rate != null
+              ? (problem.pass_rate >= 0.6 ? 'high' : problem.pass_rate >= 0.3 ? 'medium' : 'low')
+              : '';
+            const ratePct = problem.pass_rate != null ? Math.round(problem.pass_rate * 100) : null;
             return (
               <Link
                 key={problem.id}
                 to={`/problems/${problem.slug}`}
                 className={`problem-row ${status}`}
+                data-difficulty={problem.difficulty || ''}
               >
                 <span className="col-status">
                   {status === 'accepted' && <CheckCircle size={16} className="status-icon accepted" />}
@@ -219,7 +224,7 @@ export default function ProblemList() {
                   {problem.rating && problem.rating >= 800 ? (
                     <RatingBadge rating={problem.rating} size="sm" />
                   ) : (
-                    <span style={{ color: DIFFICULTY_COLORS[problem.difficulty] }}>
+                    <span style={{ color: DIFFICULTY_COLORS[problem.difficulty] || 'var(--text-secondary)' }}>
                       {problem.difficulty}
                     </span>
                   )}
@@ -236,7 +241,21 @@ export default function ProblemList() {
                   })()}
                 </span>
                 <span className="col-submissions">{problem.submission_count || 0}</span>
-                <span className={`col-rate ${problem.pass_rate != null ? (problem.pass_rate >= 0.6 ? 'high' : problem.pass_rate >= 0.3 ? 'medium' : 'low') : ''}`}>{problem.pass_rate != null ? `${Math.round(problem.pass_rate * 100)}%` : '-'}</span>
+                <span className="col-rate">
+                  {ratePct !== null ? (
+                    <>
+                      <span className="pass-rate-bar">
+                        <span
+                          className={`pass-rate-fill ${rateLevel}`}
+                          style={{ width: `${ratePct}%` }}
+                        />
+                      </span>
+                      <span className={`pass-rate-text ${rateLevel}`}>{ratePct}%</span>
+                    </>
+                  ) : (
+                    <span className="pass-rate-text">-</span>
+                  )}
+                </span>
                 <span className="col-limit">
                   <span className="limit-item">
                     <Clock size={12} /> {problem.time_limit}ms

--- a/frontend/src/pages/ProblemListDetail.css
+++ b/frontend/src/pages/ProblemListDetail.css
@@ -107,7 +107,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 

--- a/frontend/src/pages/ProblemLists.css
+++ b/frontend/src/pages/ProblemLists.css
@@ -36,7 +36,7 @@
   padding: 8px 14px;
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: var(--radius);
   color: var(--text-muted);
   min-width: 240px;
 }

--- a/frontend/src/pages/Profile.css
+++ b/frontend/src/pages/Profile.css
@@ -81,7 +81,7 @@
   border-radius: var(--radius-lg);
   width: 90%;
   max-width: 440px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 }
 
 .modal-header {
@@ -186,7 +186,7 @@
 
 .badge {
   padding: 4px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -300,7 +300,6 @@
 
 .problem-card:hover {
   border-color: var(--accent);
-  transform: translateY(-2px);
 }
 
 .problem-card.solved {

--- a/frontend/src/pages/Rankings.css
+++ b/frontend/src/pages/Rankings.css
@@ -117,7 +117,7 @@
   border: 1px solid var(--border);
   background: var(--bg-card);
   color: var(--text-secondary);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -205,7 +205,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -353,7 +352,6 @@
 .score-label {
   font-size: 12px;
   color: var(--text-muted);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 

--- a/frontend/src/pages/SolutionDetail.css
+++ b/frontend/src/pages/SolutionDetail.css
@@ -85,7 +85,7 @@
   align-items: center;
   gap: 5px;
   padding: 4px 12px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
   background: var(--accent-light);

--- a/frontend/src/pages/Solutions.css
+++ b/frontend/src/pages/Solutions.css
@@ -203,7 +203,7 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 11px;
   font-weight: 600;
   background: var(--accent-light);

--- a/frontend/src/pages/SubmissionDetail.css
+++ b/frontend/src/pages/SubmissionDetail.css
@@ -41,7 +41,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-muted);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 4px;
 }
@@ -133,7 +132,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-muted);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -214,7 +212,6 @@
   text-align: left;
   font-weight: 600;
   font-size: 12px;
-  text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--text-muted);
   border-bottom: 1px solid var(--border);
@@ -319,7 +316,6 @@
   border-radius: 4px;
   font-size: 11px;
   font-weight: 600;
-  text-transform: uppercase;
   letter-spacing: 0.5px;
   white-space: nowrap;
   background: var(--bg-tertiary);

--- a/frontend/src/pages/Submissions.css
+++ b/frontend/src/pages/Submissions.css
@@ -1,13 +1,14 @@
 .submissions-page {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
 .filter-bar {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .filter-select {
@@ -15,12 +16,15 @@
   color: var(--text-primary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 6px 12px;
-  font-size: 14px;
+  padding: 5px 10px;
+  font-size: 13px;
   outline: none;
+  cursor: pointer;
+  transition: border-color var(--transition);
 }
 
-.filter-select:focus {
+.filter-select:focus,
+.filter-select:hover {
   border-color: var(--accent);
 }
 
@@ -31,7 +35,8 @@
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 6px 12px;
+  padding: 5px 10px;
+  color: var(--text-muted);
 }
 
 .user-search-input input {
@@ -39,7 +44,7 @@
   border: none;
   outline: none;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
   width: 140px;
 }
 
@@ -47,10 +52,12 @@
   color: var(--text-muted);
 }
 
+/* ── Submissions Table ── */
 .submissions-table {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
+  overflow: hidden;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
@@ -63,8 +70,7 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border);
   min-width: 700px;
 }
 
@@ -72,23 +78,28 @@
   display: flex;
   align-items: center;
   padding: 10px 14px;
-  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
   transition: background var(--transition);
   text-decoration: none;
   color: var(--text-primary);
   min-width: 700px;
 }
 
+.submission-row:last-child {
+  border-bottom: none;
+}
+
 .submission-row:hover {
   background: var(--bg-tertiary);
 }
 
-.col-id { width: 60px; color: var(--text-muted); font-size: 14px; }
+.col-id { width: 60px; color: var(--text-muted); font-size: 13px; }
 .col-user { width: 100px; color: var(--text-secondary); font-size: 13px; }
-.col-problem { flex: 1; font-weight: 500; }
+.col-problem { flex: 1; font-weight: 500; font-size: 14px; }
+.col-problem:hover { color: var(--accent); }
 .col-lang { width: 100px; color: var(--text-secondary); font-size: 13px; }
 .col-status { width: 140px; }
-.col-score { width: 60px; text-align: center; }
+.col-score { width: 60px; text-align: center; font-weight: 600; }
 .col-time { width: 80px; color: var(--text-secondary); font-size: 13px; }
 .col-memory { width: 90px; color: var(--text-secondary); font-size: 13px; }
 .col-date { width: 160px; color: var(--text-muted); font-size: 12px; }
@@ -98,14 +109,15 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  padding: 80px 0;
+  gap: 12px;
+  padding: 60px 0;
   text-align: center;
 }
 
 .empty-page h2 {
   color: var(--text-secondary);
   font-weight: 500;
+  font-size: 16px;
 }
 
 .empty-page .empty-icon {
@@ -115,7 +127,7 @@
 
 .empty-page .empty-desc {
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: 13px;
   margin: 0;
 }
 

--- a/frontend/src/pages/Teams.css
+++ b/frontend/src/pages/Teams.css
@@ -1,4 +1,4 @@
-﻿.teams-page {
+.teams-page {
   max-width: 1100px;
   margin: 0 auto;
   padding: 24px;
@@ -33,8 +33,8 @@
   align-items: center;
   gap: 8px;
   padding: 6px 12px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   min-width: 240px;
 }
@@ -58,8 +58,8 @@
   align-items: center;
   gap: 14px;
   padding: 16px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   text-decoration: none;
   color: inherit;
@@ -67,9 +67,7 @@
 }
 
 .team-card:hover {
-  transform: translateY(-2px);
   border-color: var(--accent);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
 }
 
 .team-avatar {
@@ -108,7 +106,7 @@
 .team-desc {
   margin: 0 0 4px 0;
   font-size: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -117,7 +115,7 @@
 
 .team-meta {
   font-size: 12px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .team-detail-page {
@@ -130,7 +128,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   text-decoration: none;
   font-size: 13px;
   margin-bottom: 16px;
@@ -144,8 +142,8 @@
   display: flex;
   gap: 20px;
   padding: 24px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   margin-bottom: 24px;
 }
@@ -163,7 +161,7 @@
   display: flex;
   gap: 12px;
   font-size: 13px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   margin-top: 6px;
 }
 
@@ -190,7 +188,7 @@
   display: flex;
   gap: 6px;
   margin-bottom: 16px;
-  border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-bottom: 1px solid var(--border);
 }
 
 .team-tab {
@@ -201,7 +199,7 @@
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 14px;
 }
@@ -223,8 +221,8 @@
   align-items: center;
   gap: 12px;
   padding: 12px 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
 }
 
@@ -232,7 +230,7 @@
   width: 24px;
   text-align: center;
   font-weight: 600;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .member-avatar {
@@ -282,12 +280,12 @@
 
 .member-role.member {
   background: rgba(255, 255, 255, 0.06);
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .member-stats {
   font-size: 12px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .create-team-page {
@@ -317,8 +315,8 @@
 .create-team-form input,
 .create-team-form textarea {
   padding: 10px 12px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   color: inherit;
   outline: none;
@@ -338,7 +336,7 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .empty-state p {

--- a/frontend/src/pages/TicketDetail.css
+++ b/frontend/src/pages/TicketDetail.css
@@ -214,7 +214,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -225,7 +225,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -236,7 +236,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -247,7 +247,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }

--- a/frontend/src/pages/Tickets.css
+++ b/frontend/src/pages/Tickets.css
@@ -55,7 +55,7 @@
   border: 1px solid var(--border);
   background: var(--bg-card);
   color: var(--text-secondary);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
@@ -136,7 +136,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -147,7 +147,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }

--- a/frontend/src/pages/Training.css
+++ b/frontend/src/pages/Training.css
@@ -1,4 +1,4 @@
-﻿.training-page {
+.training-page {
   max-width: 1200px;
   margin: 0 auto;
   padding: 24px;
@@ -28,8 +28,8 @@
   align-items: center;
   gap: 8px;
   padding: 8px 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   min-width: 280px;
 }
@@ -51,8 +51,8 @@
 .training-card {
   display: flex;
   flex-direction: column;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   overflow: hidden;
   text-decoration: none;
@@ -61,8 +61,6 @@
 }
 
 .training-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
   border-color: var(--accent);
 }
 
@@ -102,18 +100,18 @@
 }
 
 .official-badge {
-  background: linear-gradient(135deg, #ffc800, #ff7c00);
+  background: var(--warning);
   color: #fff;
   font-size: 11px;
   padding: 2px 8px;
-  border-radius: 999px;
+  border-radius: var(--radius);
   font-weight: 600;
 }
 
 .training-card-desc {
   margin: 0;
   font-size: 13px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -127,7 +125,7 @@
   gap: 12px;
   flex-wrap: wrap;
   font-size: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .difficulty-tag {
@@ -153,20 +151,20 @@
 
 .progress-bar {
   height: 6px;
-  background: var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--border);
   border-radius: 3px;
   overflow: hidden;
 }
 
 .progress-bar-inner {
   height: 100%;
-  background: linear-gradient(90deg, #52c41a, #3498db);
+  background: var(--accent);
   transition: width 0.4s;
 }
 
 .progress-text {
   font-size: 11px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 /* Detail page */
@@ -182,8 +180,8 @@
   gap: 12px;
   margin-bottom: 24px;
   padding: 24px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
 }
 
@@ -198,7 +196,7 @@
   gap: 16px;
   flex-wrap: wrap;
   font-size: 13px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .training-detail-header .progress-section {
@@ -215,8 +213,8 @@
 }
 
 .chapter-item {
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 10px;
   overflow: hidden;
 }
@@ -282,13 +280,13 @@
 
 .chapter-problem-row .problem-meta {
   font-size: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .empty-chapter {
   padding: 16px;
   text-align: center;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   font-size: 13px;
 }
 

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -417,3 +417,45 @@
   border-radius: 3px;
   transition: width var(--transition);
 }
+
+/* ── Luogu-style page title with left accent bar ── */
+.page-title {
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0;
+  position: relative;
+  padding-left: 12px;
+}
+
+.page-title::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 18px;
+  background: var(--accent);
+  border-radius: 2px;
+}
+
+/* ── Luogu-style section/card header with left accent bar ── */
+.section-title {
+  position: relative;
+  padding-left: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.section-title::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 14px;
+  background: var(--accent);
+  border-radius: 2px;
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -39,9 +39,12 @@
   --diff-noi: #0E1D69;
   --header-gradient: linear-gradient(90deg, #5BA5C5, #CF94C5);
   --radius: 3px;
+  --radius-md: 3px;
   --radius-lg: 4px;
   --radius-xl: 6px;
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 2px 8px rgba(0, 0, 0, 0.08);
   --shadow-accent: none;
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04);
@@ -82,6 +85,8 @@
   --bronze: #A0785A;
   --bronze-bg: rgba(160, 120, 90, 0.15);
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 2px 8px rgba(0, 0, 0, 0.4);
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3);
 }

--- a/judge-repo/.github/workflows/judge.yml
+++ b/judge-repo/.github/workflows/judge.yml
@@ -17,17 +17,11 @@ jobs:
       - name: Extract submission info
         id: info
         run: |
-          # Get the list of changed files in the latest commit
-          # Use git diff against the parent commit to find submission files
-          FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null | grep 'submissions/' | head -1)
-          # Fallback: if diff fails (e.g. first commit), try diff-tree
+          FILES=$(git diff --name-only HEAD^ HEAD 2>/dev/null | grep 'submissions/' | head -1)
           if [ -z "$FILES" ]; then
-            FILES=$(git diff-tree --no-commit-id --name-only -r HEAD | grep 'submissions/' | head -1)
+            FILES=$(find submissions/ -maxdepth 1 -type f ! -name '.gitkeep' | head -1)
           fi
-          # Fallback: list files in submissions/ directory
-          if [ -z "$FILES" ]; then
-            FILES=$(find submissions/ -type f ! -name '.gitkeep' | head -1)
-          fi
+
           echo "file=$FILES" >> $GITHUB_OUTPUT
           FILENAME=$(basename "$FILES")
           SUBMISSION_ID=$(echo "$FILENAME" | sed 's/\.[^.]*$//')
@@ -57,7 +51,7 @@ jobs:
             echo "ERROR: No submission ID found"
             exit 1
           fi
-          RESPONSE=$(curl -s -H "Authorization: Bearer $CALLBACK_SECRET" \
+          RESPONSE=$(curl -s --max-time 10 --retry 3 -H "Authorization: Bearer $CALLBACK_SECRET" \
             "${WORKER_API}/api/v1/internal/judge-data?submission_id=${SUBMISSION_ID}")
           echo "$RESPONSE" > judge_data.json
           echo "Fetched judge data for submission $SUBMISSION_ID"
@@ -74,43 +68,40 @@ jobs:
           LANGUAGE="${{ steps.info.outputs.language }}"
           SPJ_LANGUAGE="${{ steps.spj_info.outputs.spj_language }}"
 
-          # Function to install a language runtime
           install_language() {
             local lang="$1"
             case "$lang" in
               python)
-                # Python3 is pre-installed on ubuntu-latest
                 python3 --version
                 ;;
               cpp)
-                sudo apt-get update && sudo apt-get install -y g++
+                sudo apt-get update -o Acquire::LockTimeout=30 -o APT::Install-Suggests=0
+                sudo apt-get install -y g++
                 ;;
               java)
-                sudo apt-get update && sudo apt-get install -y default-jdk
+                sudo apt-get update -o Acquire::LockTimeout=30
+                sudo apt-get install -y default-jdk
                 ;;
               javascript)
-                # Node.js is pre-installed on ubuntu-latest
                 node --version
                 ;;
               c)
-                sudo apt-get update && sudo apt-get install -y gcc
+                sudo apt-get update -o Acquire::LockTimeout=30
+                sudo apt-get install -y gcc
                 ;;
               go)
-                sudo apt-get update && sudo apt-get install -y golang-go
+                sudo apt-get update -o Acquire::LockTimeout=30
+                sudo apt-get install -y golang-go
                 ;;
               rust)
-                curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+                curl --connect-timeout 10 --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
                 source "$HOME/.cargo/env"
                 ;;
             esac
           }
 
-          # Install submission language runtime
           install_language "$LANGUAGE"
-
-          # Install SPJ language runtime if different from submission language
           if [ -n "$SPJ_LANGUAGE" ] && [ "$SPJ_LANGUAGE" != "$LANGUAGE" ]; then
-            echo "Also installing SPJ language runtime: $SPJ_LANGUAGE"
             install_language "$SPJ_LANGUAGE"
           fi
 
@@ -118,6 +109,7 @@ jobs:
         id: judge
         run: |
           chmod +x scripts/judge.sh
+          ulimit -t 5
           bash scripts/judge.sh
         env:
           SUBMISSION_ID: ${{ steps.info.outputs.submission_id }}
@@ -131,21 +123,38 @@ jobs:
           WORKER_API: ${{ secrets.WORKER_API }}
           SUBMISSION_ID: ${{ steps.info.outputs.submission_id }}
         run: |
+          set -o errexit
+          if [ -z "$SUBMISSION_ID" ]; then
+            echo "ERROR submission_id empty, skip callback"
+            exit 0
+          fi
+          CALL_URL="${WORKER_API}/api/v1/internal/callback"
           if [ -f result.json ]; then
-            curl -s -X POST "${WORKER_API}/api/v1/internal/callback" \
+            echo "Send normal callback, file content:"
+            cat result.json
+            RESP=$(curl -X POST "$CALL_URL" \
+              --max-time 10 --retry 2 \
               -H "Authorization: Bearer $CALLBACK_SECRET" \
               -H "Content-Type: application/json" \
-              -d @result.json
-            echo "Callback sent successfully"
-          else
-            if [ -n "$SUBMISSION_ID" ]; then
-              echo "{\"submission_id\": \"$SUBMISSION_ID\", \"status\": \"system_error\", \"details\": [{\"status\": \"system_error\", \"message\": \"Judge failed to produce result\"}]}" > fallback_result.json
-              curl -s -X POST "${WORKER_API}/api/v1/internal/callback" \
+              -d @result.json -w $'\nHTTP_CODE=%{http_code}' 2>&1)
+            echo "$RESP"
+            if echo "$RESP" | grep -q "HTTP_CODE=200"; then
+              echo "Callback success"
+            else
+              echo "Callback request failed, trigger fallback"
+              echo "{\"submission_id\":\"$SUBMISSION_ID\",\"status\":\"system_error\",\"details\":[{\"message\":\"Judge callback request failed\"}]}" > fallback_result.json
+              curl -X POST "$CALL_URL" \
+                --max-time 10 --retry 2 \
                 -H "Authorization: Bearer $CALLBACK_SECRET" \
                 -H "Content-Type: application/json" \
                 -d @fallback_result.json
-              echo "Fallback callback sent"
-            else
-              echo "ERROR: No submission ID available for callback"
             fi
+          else
+            echo "No result.json, send system error fallback"
+            echo "{\"submission_id\": \"$SUBMISSION_ID\", \"status\": \"system_error\", \"details\": [{\"status\": \"system_error\", \"message\": \"Judge failed to produce result\"}]}" > fallback_result.json
+            curl -X POST "$CALL_URL" \
+              --max-time 10 --retry 2 \
+              -H "Authorization: Bearer $CALLBACK_SECRET" \
+              -H "Content-Type: application/json" \
+              -d @fallback_result.json
           fi


### PR DESCRIPTION
## Summary

继续 Luogu UI 复刻工作，包含 Phase B/C/D 三个阶段 + UTF-8 编码修复，并同步 main 分支最新评测逻辑改动，确保 luogu-style 不落后于 main。

### Phase B: 核心页面 Luogu 化（6 文件，+344/-216）
- **Home.css**: 卡片标题加左侧蓝色色条、hitokoto 改为水平条、圆角统一 3-4px、扁平设计
- **ProblemList.css + .tsx**: 表格行加 `data-difficulty` 属性 + 左侧 3px 难度色条；通过率改为进度条+百分比；难度筛选下拉改为 Luogu 11 级；header 移除 uppercase
- **ProblemDetail.css + .tsx**: 难度徽章 3px 圆角 + `data-difficulty` 背景色（修复 `var()20` 失效内联样式）；meta-item 圆角 3px；sample-box label 移除 uppercase
- **Submissions.css**: header 移除 uppercase、行改用 border-bottom、圆角统一

### Phase C: 全页面 Luogu 风格统一（28 文件，+188/-171）
批量机械修复跨 20 个页面 CSS：
- 移除 13 处 `text-transform: uppercase` + 1 处 `capitalize`
- 28 处 `border-radius: 20px`（胶囊）改为 `var(--radius)`（3px）
- 5 处 `rgba(108,140,255)` 旧 indigo fallback 清理
- 87 处遗留 `var` fallback 清理

拍平渐变与大阴影：
- Admin.css 7 处 `linear-gradient` 改扁平背景
- Training.css official-badge/progress-bar 渐变改扁平
- Teams.css/Blogs.css/Profile.css 卡片 hover 去除 translateY+大阴影
- Admin/Messages/Profile 模态框大阴影降至 `0 4px 16px`

全局增强（components.css）：新增 `.page-title` 与 `.section-title` 左侧蓝色色条规则

### Phase D: 补全缺失 CSS 变量（1 文件，+5）
- global.css 新增 `--radius-md` / `--shadow-sm` / `--shadow-md`，修复 Login 页面 toggle 按钮与输入框因变量未定义而显示 0 圆角的问题

### UTF-8 编码修复
- 修复 ProblemDetail.css 中「省选」「省选-」选择器的 UTF-8 编码损坏（PowerShell 写入导致「选」字末字节 0x89 被替换为 0x3F）

### 同步 main
合并 `origin/main`（`a5b28bc` 完善评测逻辑，处理并发评测场景），仅涉及 `judge-repo/.github/workflows/judge.yml`，与前端 UI 改动无冲突。

## 验证
- ✅ TypeScript 检查通过（`npx tsc --noEmit` exit 0）
- ✅ `npm run build:assets` 构建成功（vite build ✓ 1.34s）
- ✅ 浏览器截图验证 8+ 页面渲染正常（标题蓝色色条、3-4px 圆角、无 uppercase、扁平蓝色风格一致）

## Test plan
- [ ] 启动 `npx vite`，逐页检查 Home / ProblemList / ProblemDetail / Submissions / Contests / Discussions / Solutions / Lists / Notifications / Rankings
- [ ] 切换暗色主题验证深色模式下颜色变量正常
- [ ] 验证题目列表难度筛选为 Luogu 11 级、行左侧难度色条、通过率进度条
- [ ] 验证题目详情难度徽章背景色与难度对应
- [ ] 验证登录页 toggle 按钮/输入框为 3px 圆角
- [ ] 验证 `npm run build:site` 构建成功