### PR TITLE
fix: 修复提交代码验证码功能及批量修复 useToastStore hook 误用

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -166,7 +166,7 @@ class ApiClient {
     });
   }
 
-  async submitCode(data: { problem_id: number; language: string; source_code: string }) {
+  async submitCode(data: { problem_id: number; language: string; source_code: string; captcha_uuid?: string; captcha_answer?: string }) {
     return this.request<{ submission_id: number; status: string }>('/submissions', {
       method: 'POST',
       body: JSON.stringify(data),

--- a/frontend/src/components/ImageUploadButton.tsx
+++ b/frontend/src/components/ImageUploadButton.tsx
@@ -11,6 +11,7 @@ interface ImageUploadButtonProps {
 }
 
 export default function ImageUploadButton({ onInsert }: ImageUploadButtonProps) {
+  const addToast = useToastStore((s) => s.addToast);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [uploading, setUploading] = useState(false);
   const getImageUploadEnabled = useSettingsStore((s) => s.getImageUploadEnabled);
@@ -30,9 +31,9 @@ export default function ImageUploadButton({ onInsert }: ImageUploadButtonProps) 
       const result = await api.uploadImage(file);
       const markdown = `![${result.original_name}](${result.url})`;
       onInsert(markdown);
-      useToastStore().addToast('success', t('common.uploadSuccess'));
+      addToast('success', t('common.uploadSuccess'));
     } catch (err: any) {
-      useToastStore().addToast('error', err.message || t('common.uploadFailed'));
+      addToast('error', err.message || t('common.uploadFailed'));
     } finally {
       setUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';

--- a/frontend/src/pages/DiscussionDetail.tsx
+++ b/frontend/src/pages/DiscussionDetail.tsx
@@ -29,6 +29,7 @@ export default function DiscussionDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { user } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
 
   const [discussion, setDiscussion] = useState<any>(null);
   const [replies, setReplies] = useState<any[]>([]);
@@ -56,7 +57,7 @@ export default function DiscussionDetail() {
       setDiscussion(data.discussion);
       setReplies(data.replies || []);
     } catch (e: any) {
-      useToastStore().addToast('error', t('common.loadError'));
+      addToast('error', t('common.loadError'));
       console.error('Failed to fetch discussion:', e);
     } finally {
       setLoading(false);
@@ -71,7 +72,7 @@ export default function DiscussionDetail() {
       setReplyContent('');
       fetchDiscussion();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
       console.error('Failed to reply:', e);
     } finally {
       setSubmitting(false);
@@ -85,7 +86,7 @@ export default function DiscussionDetail() {
       await api.deleteDiscussion(Number(id));
       navigate('/discussions');
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
       console.error('Failed to delete discussion:', e);
     }
   };
@@ -97,7 +98,7 @@ export default function DiscussionDetail() {
       await api.deleteDiscussionReply(Number(id), replyId);
       fetchDiscussion();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
       console.error('Failed to delete reply:', e);
     }
   };
@@ -122,7 +123,7 @@ export default function DiscussionDetail() {
       setIsEditing(false);
       fetchDiscussion();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
       console.error('Failed to update discussion:', e);
     } finally {
       setEditSubmitting(false);

--- a/frontend/src/pages/Discussions.tsx
+++ b/frontend/src/pages/Discussions.tsx
@@ -34,6 +34,7 @@ export default function Discussions() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { user } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
 
   const problemId = searchParams.get('problem_id');
   const problemTitle = searchParams.get('problem_title');
@@ -111,7 +112,7 @@ export default function Discussions() {
       if (e.message?.includes('CAPTCHA')) {
         captchaRef.current?.refresh();
       }
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     } finally {
       setSubmitting(false);
     }

--- a/frontend/src/pages/GlobalDiscussions.tsx
+++ b/frontend/src/pages/GlobalDiscussions.tsx
@@ -27,6 +27,7 @@ const formatDate = (dateStr: string) => {
 };
 
 export default function GlobalDiscussions() {
+  const addToast = useToastStore((s) => s.addToast);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [discussions, setDiscussions] = useState<any[]>([]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -55,7 +56,7 @@ export default function GlobalDiscussions() {
       setDiscussions(data.discussions || []);
       setPagination(data.pagination || null);
     } catch (e) {
-      useToastStore().addToast('error', t('common.loadError'));
+      addToast('error', t('common.loadError'));
       console.error('Failed to fetch discussions:', e);
       setLoadError(true);
     } finally {

--- a/frontend/src/pages/GlobalSolutions.tsx
+++ b/frontend/src/pages/GlobalSolutions.tsx
@@ -24,6 +24,7 @@ const SORT_OPTIONS = [
 ];
 
 export default function GlobalSolutions() {
+  const addToast = useToastStore((s) => s.addToast);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [solutions, setSolutions] = useState<any[]>([]);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -53,7 +54,7 @@ export default function GlobalSolutions() {
       setSolutions(data.solutions || []);
       setPagination(data.pagination || {});
     } catch (e) {
-      useToastStore().addToast('error', t('common.loadError'));
+      addToast('error', t('common.loadError'));
       console.error('Failed to fetch solutions:', e);
       setLoadError(true);
     } finally {

--- a/frontend/src/pages/MyFiles.tsx
+++ b/frontend/src/pages/MyFiles.tsx
@@ -12,6 +12,7 @@ import './MyFiles.css';
 
 export default function MyFiles() {
   const { user } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
   const getImageUploadEnabled = useSettingsStore((s) => s.getImageUploadEnabled);
   const getUploadEnabled = useSettingsStore((s) => s.getUploadEnabled);
   const perms = usePermissions();
@@ -43,7 +44,7 @@ export default function MyFiles() {
       setUploads(data.uploads);
       setTotalPages(data.pagination.totalPages);
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     } finally {
       setLoading(false);
     }
@@ -61,14 +62,14 @@ export default function MyFiles() {
     try {
       if (activeTab === 'image') {
         await api.uploadImage(file);
-        useToastStore().addToast('success', t('common.uploadSuccess'));
+        addToast('success', t('common.uploadSuccess'));
       } else {
         await api.uploadFile(file);
-        useToastStore().addToast('success', t('common.uploadSuccess'));
+        addToast('success', t('common.uploadSuccess'));
       }
       fetchUploads(page);
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.uploadFailed'));
+      addToast('error', e.message || t('common.uploadFailed'));
     } finally {
       setUploading(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
@@ -79,10 +80,10 @@ export default function MyFiles() {
     if (!confirm(t('common.deleteConfirm'))) return;
     try {
       await api.deleteUpload(id);
-      useToastStore().addToast('success', t('common.deleteSuccess'));
+      addToast('success', t('common.deleteSuccess'));
       fetchUploads(page);
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 
@@ -97,10 +98,10 @@ export default function MyFiles() {
     try {
       await navigator.clipboard.writeText(markdown);
       setCopiedId(item.id);
-      useToastStore().addToast('success', t('common.copied'));
+      addToast('success', t('common.copied'));
       setTimeout(() => setCopiedId(null), 2000);
     } catch {
-      useToastStore().addToast('error', t('common.error'));
+      addToast('error', t('common.error'));
     }
   };
 

--- a/frontend/src/pages/ProblemDetail.tsx
+++ b/frontend/src/pages/ProblemDetail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuthStore } from '../store/auth';
+import { useSettingsStore } from '../store/settings';
 import CodeMirror from '@uiw/react-codemirror';
 import ImageUploadButton from '../components/ImageUploadButton';
 import { python } from '@codemirror/lang-python';
@@ -12,6 +13,7 @@ import { oneDark } from '@codemirror/theme-one-dark';
 import { useThemeStore } from '../store/theme';
 import { useToastStore } from '../store/toast';
 import StatusBadge from '../components/StatusBadge';
+import Captcha, { type CaptchaHandle } from '../components/Captcha';
 import { Send, Clock, MemoryStick, ChevronLeft, ChevronRight, Tag, Heart, CheckCircle, XCircle, AlertCircle, Users, BookOpen, MessageSquare, ThumbsUp, Eye, Plus, X, Sparkles, Flag } from 'lucide-react';
 import { LANGUAGES, LANGUAGE_TEMPLATES, DIFFICULTY_COLORS } from '../constants';
 import RatingBadge from '../components/RatingBadge';
@@ -90,6 +92,15 @@ export default function ProblemDetail() {
   const [reportDescription, setReportDescription] = useState('');
   const [reportSubmitting, setReportSubmitting] = useState(false);
   const addToast = useToastStore((s) => s.addToast);
+
+  // ── Captcha state (only used when captcha_submit is enabled) ──
+  // Subscribe to settings object so component re-renders when settings load.
+  const settings = useSettingsStore((s) => s.settings);
+  const settingsLoaded = useSettingsStore((s) => s.loaded);
+  const captchaEnabled = settings.captcha_enabled !== 'false' && settings.captcha_submit === 'true';
+  const [captchaUuid, setCaptchaUuid] = useState('');
+  const [captchaAnswer, setCaptchaAnswer] = useState('');
+  const captchaRef = useRef<CaptchaHandle>(null);
 
   // ── Fetch problem on slug change (Bug 8 fix: separate effects) ──
 
@@ -403,6 +414,16 @@ export default function ProblemDetail() {
       return;
     }
     if (!problem || submitting) return;
+    // Wait for settings to load so we know whether captcha is required
+    if (!settingsLoaded) {
+      addToast('error', t('common.loading'));
+      return;
+    }
+
+    if (captchaEnabled && !captchaAnswer.trim()) {
+      addToast('error', t('login.captcha'));
+      return;
+    }
 
     setSubmitting(true);
     setLastStatus('pending');
@@ -411,14 +432,34 @@ export default function ProblemDetail() {
         problem_id: problem.id,
         language,
         source_code: sourceCode,
+        captcha_uuid: captchaEnabled ? captchaUuid : undefined,
+        captcha_answer: captchaEnabled ? captchaAnswer.trim() : undefined,
       });
       setLastSubmissionId(result.submission_id);
       pollSubmission(result.submission_id);
       // Clear draft after successful submission (Bug 6 fix)
       if (slug) localStorage.removeItem(DRAFT_KEY(slug, language));
+      // Reset captcha after successful submission
+      if (captchaEnabled) {
+        setCaptchaAnswer('');
+        captchaRef.current?.refresh();
+      }
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      const msg = e.message || t('common.error');
+      // Detect captcha-related errors and give clear feedback
+      if (/captcha/i.test(msg)) {
+        addToast('error', t('login.captcha') + ': ' + msg);
+      } else {
+        addToast('error', msg);
+      }
       setLastStatus(null);
+      // Always refresh captcha on failure — the used uuid is now invalid
+      // (backend marks it used regardless of success/failure)
+      if (captchaEnabled) {
+        setCaptchaAnswer('');
+        setCaptchaUuid('');
+        captchaRef.current?.refresh();
+      }
     } finally {
       if (isMountedRef.current) setSubmitting(false);
     }
@@ -518,7 +559,7 @@ export default function ProblemDetail() {
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [handleSubmit, submitting, problem, user, sourceCode, language]);
+  }, [handleSubmit, submitting, problem, user, sourceCode, language, captchaAnswer, captchaUuid, captchaEnabled, settingsLoaded]);
 
   const getLangExtension = (lang: string) => {
     switch (lang) {
@@ -1167,7 +1208,7 @@ export default function ProblemDetail() {
             <button
               className={`btn btn-primary ${submitting ? 'btn-loading' : ''}`}
               onClick={handleSubmit}
-              disabled={submitting}
+              disabled={submitting || !settingsLoaded}
               title="Ctrl+Enter"
             >
               <Send size={14} />
@@ -1214,6 +1255,17 @@ export default function ProblemDetail() {
             onChange={handleSourceCodeChange}
           />
         </div>
+
+        {captchaEnabled && (
+          <div style={{ padding: '12px 16px', borderTop: '1px solid var(--border-color)', background: 'var(--bg-hover)' }}>
+            <Captcha
+              ref={captchaRef}
+              onCaptchaReady={(data) => setCaptchaUuid(data.uuid)}
+              onCaptchaChange={setCaptchaAnswer}
+              captchaAnswer={captchaAnswer}
+            />
+          </div>
+        )}
 
         {lastStatus && (
           <div className="submit-result">

--- a/frontend/src/pages/ProblemList.tsx
+++ b/frontend/src/pages/ProblemList.tsx
@@ -12,6 +12,7 @@ import './ProblemList.css';
 
 export default function ProblemList() {
   const { user } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
   const [problems, setProblems] = useState<any[]>([]);
   const [pagination, setPagination] = useState<any>({});
   const [search, setSearch] = useState('');
@@ -58,7 +59,7 @@ export default function ProblemList() {
       setProblems(data.problems);
       setPagination(data.pagination);
     } catch (e: any) {
-      useToastStore().addToast('error', t('common.loadError'));
+      addToast('error', t('common.loadError'));
       console.error('Failed to fetch problems:', e);
       setError(e.message || t('common.error'));
     } finally {
@@ -80,7 +81,7 @@ export default function ProblemList() {
       );
       setAttemptedProblems(attemptedIds);
     } catch (e) {
-      useToastStore().addToast('error', t('common.error'));
+      addToast('error', t('common.error'));
       console.error('Failed to fetch user progress:', e);
     }
   };

--- a/frontend/src/pages/ProblemListDetail.tsx
+++ b/frontend/src/pages/ProblemListDetail.tsx
@@ -9,6 +9,7 @@ import './ProblemListDetail.css';
 
 export default function ProblemListDetail() {
   const { id } = useParams<{ id: string }>();
+  const addToast = useToastStore((s) => s.addToast);
   const [list, setList] = useState<any>(null);
   const [items, setItems] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
@@ -26,7 +27,7 @@ export default function ProblemListDetail() {
       setList(data.list);
       setItems(data.items || []);
     } catch (e) {
-      useToastStore().addToast('error', t('problemListDetail.loadError'));
+      addToast('error', t('problemListDetail.loadError'));
       console.error('Failed to fetch problem list:', e);
       setLoadError(true);
     } finally {

--- a/frontend/src/pages/Solutions.tsx
+++ b/frontend/src/pages/Solutions.tsx
@@ -23,6 +23,7 @@ const LANGUAGE_NAMES: Record<string, string> = {
 };
 
 export default function Solutions() {
+  const addToast = useToastStore((s) => s.addToast);
   const SORT_OPTIONS = [
     { value: 'newest', label: t('solutions.newest') },
     { value: 'popular', label: t('solutions.popular') },
@@ -80,7 +81,7 @@ export default function Solutions() {
       setSolutions(data.solutions);
       setPagination(data.pagination);
     } catch (e) {
-      useToastStore().addToast('error', t('common.loadError'));
+      addToast('error', t('common.loadError'));
       console.error('Failed to fetch solutions:', e);
       setLoadError(true);
     } finally {

--- a/frontend/src/pages/SubmissionDetail.tsx
+++ b/frontend/src/pages/SubmissionDetail.tsx
@@ -31,6 +31,7 @@ export default function SubmissionDetail() {
   const { id } = useParams<{ id: string }>();
   const { user } = useAuthStore();
   const { theme } = useThemeStore();
+  const addToast = useToastStore((s) => s.addToast);
   const [submission, setSubmission] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -110,7 +111,7 @@ export default function SubmissionDetail() {
       await api.rejudgeSubmission(submission.id);
       fetchSubmission();
     } catch {
-      useToastStore().addToast('error', t('submissionDetail.rejudgeFailed'));
+      addToast('error', t('submissionDetail.rejudgeFailed'));
     } finally {
       setRejudging(false);
     }

--- a/frontend/src/pages/TicketDetail.tsx
+++ b/frontend/src/pages/TicketDetail.tsx
@@ -32,6 +32,7 @@ const CATEGORY_BADGE_CLASS: Record<string, string> = {
 export default function TicketDetail() {
   const { id } = useParams<{ id: string }>();
   const { user } = useAuthStore();
+  const addToast = useToastStore((s) => s.addToast);
   const [ticket, setTicket] = useState<any>(null);
   const [replies, setReplies] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
@@ -53,7 +54,7 @@ export default function TicketDetail() {
       setTicket(data.ticket);
       setReplies(data.replies || []);
     } catch (e: any) {
-      useToastStore().addToast('error', t('ticketDetail.loadError'));
+      addToast('error', t('ticketDetail.loadError'));
       console.error('Failed to fetch ticket:', e);
       setLoadError(true);
     } finally {
@@ -69,7 +70,7 @@ export default function TicketDetail() {
       setReplyContent('');
       fetchTicket();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
       console.error('Failed to reply:', e);
     } finally {
       setSubmitting(false);
@@ -82,7 +83,7 @@ export default function TicketDetail() {
       await api.updateTicketStatus(Number(id), { status: newStatus });
       fetchTicket();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
       console.error('Failed to update status:', e);
     }
   };
@@ -93,7 +94,7 @@ export default function TicketDetail() {
       await api.updateTicketStatus(Number(id), { priority: newPriority });
       fetchTicket();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
       console.error('Failed to update priority:', e);
     }
   };

--- a/frontend/src/pages/admin/AdminAnnouncement.tsx
+++ b/frontend/src/pages/admin/AdminAnnouncement.tsx
@@ -8,6 +8,7 @@ import '../Admin.css';
 
 export default function AdminAnnouncement() {
   useDocumentTitle(t('admin.announcementManagement'));
+  const addToast = useToastStore((s) => s.addToast);
   const [announcementContent, setAnnouncementContent] = useState('');
   const [announcementSaving, setAnnouncementSaving] = useState(false);
   const [announcementLoaded, setAnnouncementLoaded] = useState(false);
@@ -32,9 +33,9 @@ export default function AdminAnnouncement() {
     setAnnouncementSaving(true);
     try {
       await api.updateSettings({ announcement: announcementContent });
-      useToastStore().addToast('success', t('admin.announcementSaved'));
+      addToast('success', t('admin.announcementSaved'));
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     } finally {
       setAnnouncementSaving(false);
     }

--- a/frontend/src/pages/admin/AdminBans.tsx
+++ b/frontend/src/pages/admin/AdminBans.tsx
@@ -37,6 +37,7 @@ export default function AdminBans() {
 }
 
 function BannedIPsList() {
+  const addToast = useToastStore((s) => s.addToast);
   const [bans, setBans] = useState<any[]>([]);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -65,7 +66,7 @@ function BannedIPsList() {
       setNewReason('');
       fetchBans();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('admin.banFailed'));
+      addToast('error', e.message || t('admin.banFailed'));
     }
   };
 
@@ -75,7 +76,7 @@ function BannedIPsList() {
       await api.unbanIP(id);
       fetchBans();
     } catch {
-      useToastStore().addToast('error', t('admin.unbanFailed'));
+      addToast('error', t('admin.unbanFailed'));
     }
   };
 
@@ -160,6 +161,7 @@ function BannedIPsList() {
 }
 
 function BannedDevicesList() {
+  const addToast = useToastStore((s) => s.addToast);
   const [bans, setBans] = useState<any[]>([]);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -188,7 +190,7 @@ function BannedDevicesList() {
       setNewReason('');
       fetchBans();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('admin.banFailed'));
+      addToast('error', e.message || t('admin.banFailed'));
     }
   };
 
@@ -198,7 +200,7 @@ function BannedDevicesList() {
       await api.unbanDevice(id);
       fetchBans();
     } catch {
-      useToastStore().addToast('error', t('admin.unbanFailed'));
+      addToast('error', t('admin.unbanFailed'));
     }
   };
 

--- a/frontend/src/pages/admin/AdminContests.tsx
+++ b/frontend/src/pages/admin/AdminContests.tsx
@@ -10,6 +10,7 @@ import '../Admin.css';
 
 export default function AdminContests() {
   useDocumentTitle(t('admin.contestManagement'));
+  const addToast = useToastStore((s) => s.addToast);
   const [refreshKey, setRefreshKey] = useState(0);
   const refresh = () => setRefreshKey(k => k + 1);
 
@@ -33,10 +34,10 @@ export default function AdminContests() {
     if (!window.confirm(t('admin.deleteConfirm'))) return;
     try {
       await api.deleteContest(id);
-      useToastStore().addToast('success', t('common.deleteSuccess'));
+      addToast('success', t('common.deleteSuccess'));
       refresh();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 

--- a/frontend/src/pages/admin/AdminCreateProblem.tsx
+++ b/frontend/src/pages/admin/AdminCreateProblem.tsx
@@ -10,6 +10,7 @@ import '../Admin.css';
 
 export default function AdminCreateProblem() {
   useDocumentTitle(t('admin.createProblem'));
+  const addToast = useToastStore((s) => s.addToast);
   const navigate = useNavigate();
   const [saving, setSaving] = useState(false);
   const [problemForm, setProblemForm] = useState({
@@ -43,7 +44,7 @@ export default function AdminCreateProblem() {
 
   const handleCreateProblem = async () => {
     if (!problemForm.title || !problemForm.slug || !problemForm.description) {
-      useToastStore().addToast('error', t('admin.titleRequired'));
+      addToast('error', t('admin.titleRequired'));
       return;
     }
     setSaving(true);
@@ -53,10 +54,10 @@ export default function AdminCreateProblem() {
         data.spj_code = spjCode;
       }
       const result = await api.createProblem(data);
-      useToastStore().addToast('success', t('admin.problemCreated'));
+      addToast('success', t('admin.problemCreated'));
       navigate(`/admin/testcases?problemId=${result.id}&problemTitle=${encodeURIComponent(problemForm.title)}&problemSlug=${encodeURIComponent(problemForm.slug)}&problemDifficulty=${problemForm.difficulty}&problemJudgeType=${problemForm.judge_type}`);
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     } finally {
       setSaving(false);
     }

--- a/frontend/src/pages/admin/AdminLists.tsx
+++ b/frontend/src/pages/admin/AdminLists.tsx
@@ -10,6 +10,7 @@ import '../Admin.css';
 
 export default function AdminLists() {
   useDocumentTitle(t('admin.listManagement'));
+  const addToast = useToastStore((s) => s.addToast);
   const [refreshKey, setRefreshKey] = useState(0);
   const refresh = () => setRefreshKey(k => k + 1);
 
@@ -33,10 +34,10 @@ export default function AdminLists() {
     if (!window.confirm(t('admin.deleteConfirm'))) return;
     try {
       await api.deleteProblemList(id);
-      useToastStore().addToast('success', t('common.deleteSuccess'));
+      addToast('success', t('common.deleteSuccess'));
       refresh();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 

--- a/frontend/src/pages/admin/AdminModels.tsx
+++ b/frontend/src/pages/admin/AdminModels.tsx
@@ -9,6 +9,7 @@ import '../Admin.css';
 
 export default function AdminModels() {
   useDocumentTitle(t('admin.aiModels'));
+  const addToast = useToastStore((s) => s.addToast);
   const [aiModels, setAiModels] = useState<AIModelConfig[]>([]);
   const [aiModelsLoading, setAiModelsLoading] = useState(false);
   const [aiModelsSaving, setAiModelsSaving] = useState(false);
@@ -27,7 +28,7 @@ export default function AdminModels() {
       setAiModels(data.models || []);
       setAiModelsLoaded(true);
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     } finally {
       setAiModelsLoading(false);
     }
@@ -38,9 +39,9 @@ export default function AdminModels() {
     try {
       const data = await api.updateAIModels(aiModels);
       setAiModels(data.models);
-      useToastStore().addToast('success', t('admin.aiModelsSaved'));
+      addToast('success', t('admin.aiModelsSaved'));
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     } finally {
       setAiModelsSaving(false);
     }

--- a/frontend/src/pages/admin/AdminProblems.tsx
+++ b/frontend/src/pages/admin/AdminProblems.tsx
@@ -12,6 +12,7 @@ import '../Admin.css';
 
 export default function AdminProblems() {
   useDocumentTitle(t('admin.problemManagement'));
+  const addToast = useToastStore((s) => s.addToast);
   const navigate = useNavigate();
   const [refreshKey, setRefreshKey] = useState(0);
   const refresh = () => setRefreshKey(k => k + 1);
@@ -65,10 +66,10 @@ export default function AdminProblems() {
     }
     try {
       await api.deleteProblem(id);
-      useToastStore().addToast('success', t('admin.problemDeleted'));
+      addToast('success', t('admin.problemDeleted'));
       refresh();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 
@@ -89,12 +90,12 @@ export default function AdminProblems() {
   const handleSaveEdit = async (id: number) => {
     try {
       await api.updateProblem(id, editForm);
-      useToastStore().addToast('success', t('admin.problemUpdated'));
+      addToast('success', t('admin.problemUpdated'));
       setEditingProblem(null);
       setEditForm({});
       refresh();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 
@@ -135,11 +136,11 @@ export default function AdminProblems() {
 
       appendActionLog(t('admin.exportLogFinished'));
       setActionStatus(t('admin.exportComplete'));
-      useToastStore().addToast('success', t('admin.problemsExported'));
+      addToast('success', t('admin.problemsExported'));
     } catch (e: any) {
       appendActionLog(`${t('common.error')}: ${e.message || t('common.error')}`);
       setActionStatus(t('admin.exportFailed'));
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     } finally {
       setIsExporting(false);
     }
@@ -165,12 +166,12 @@ export default function AdminProblems() {
       const result = await api.importProblems(problems);
       appendActionLog(t('admin.importLogFinished').replace('{0}', String(result.imported || 0)));
       setActionStatus(t('admin.importComplete'));
-      useToastStore().addToast('success', t('admin.problemsImported').replace('{0}', String(result.imported || 0)));
+      addToast('success', t('admin.problemsImported').replace('{0}', String(result.imported || 0)));
       refresh();
     } catch (e: any) {
       appendActionLog(`${t('common.error')}: ${e.message || t('common.error')}`);
       setActionStatus(t('admin.importFailed'));
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     } finally {
       setIsImporting(false);
       if (fileInputRef.current) {

--- a/frontend/src/pages/admin/AdminSettings.tsx
+++ b/frontend/src/pages/admin/AdminSettings.tsx
@@ -41,6 +41,7 @@ export default function AdminSettings() {
   const [settingsLoaded, setSettingsLoaded] = useState(false);
 
   const fetchSettings = useSettingsStore((s) => s.fetchSettings);
+  const addToast = useToastStore((s) => s.addToast);
 
   useEffect(() => {
     if (!settingsLoaded) {
@@ -117,9 +118,9 @@ export default function AdminSettings() {
         captcha_solution: String(settingsCaptchaSolution),
       });
       await fetchSettings(true);
-      useToastStore().addToast('success', t('admin.settingsSaved'));
+      addToast('success', t('admin.settingsSaved'));
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     } finally {
       setSettingsSaving(false);
     }

--- a/frontend/src/pages/admin/AdminTestcases.tsx
+++ b/frontend/src/pages/admin/AdminTestcases.tsx
@@ -12,6 +12,7 @@ import '../Admin.css';
 
 export default function AdminTestcases() {
   useDocumentTitle(t('admin.addTestcases'));
+  const addToast = useToastStore((s) => s.addToast);
   const [searchParams] = useSearchParams();
   const [saving, setSaving] = useState(false);
 
@@ -59,7 +60,7 @@ export default function AdminTestcases() {
 
   const handleSaveTestcases = async () => {
     if (!selectedTestcaseProblem) {
-      useToastStore().addToast('error', t('admin.selectProblemFirst'));
+      addToast('error', t('admin.selectProblemFirst'));
       return;
     }
     const isSpj = selectedProblemJudgeType === 'spj';
@@ -70,18 +71,18 @@ export default function AdminTestcases() {
       return tc.input && tc.expected_output;
     });
     if (validTestcases.length === 0) {
-      useToastStore().addToast('error', t('admin.atLeastOneTestcase'));
+      addToast('error', t('admin.atLeastOneTestcase'));
       return;
     }
     setSaving(true);
     try {
       await api.addTestcases(selectedTestcaseProblem.id, validTestcases);
-      useToastStore().addToast('success', t('admin.testcaseAdded'));
+      addToast('success', t('admin.testcaseAdded'));
       setTestcases([{ input: '', expected_output: '', is_sample: false, score: 10 }]);
       const data = await api.getProblemTestcases(selectedTestcaseProblem.id);
       setExistingTestcases(data.testcases);
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     } finally {
       setSaving(false);
     }
@@ -92,11 +93,11 @@ export default function AdminTestcases() {
     if (!window.confirm(t('admin.deleteTestcaseConfirm'))) return;
     try {
       await api.deleteTestcase(selectedTestcaseProblem.id, index);
-      useToastStore().addToast('success', t('admin.testcaseDeleted'));
+      addToast('success', t('admin.testcaseDeleted'));
       const data = await api.getProblemTestcases(selectedTestcaseProblem.id);
       setExistingTestcases(data.testcases);
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 

--- a/frontend/src/pages/admin/AdminTickets.tsx
+++ b/frontend/src/pages/admin/AdminTickets.tsx
@@ -10,6 +10,7 @@ import '../Admin.css';
 
 export default function AdminTickets() {
   useDocumentTitle(t('admin.ticketManagement'));
+  const addToast = useToastStore((s) => s.addToast);
   const [refreshKey, setRefreshKey] = useState(0);
   const refresh = () => setRefreshKey(k => k + 1);
 
@@ -33,10 +34,10 @@ export default function AdminTickets() {
   const handleTicketStatusChange = async (id: number, status: string) => {
     try {
       await api.updateTicketStatus(id, { status });
-      useToastStore().addToast('success', t('common.success'));
+      addToast('success', t('common.success'));
       refresh();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 

--- a/frontend/src/pages/admin/AdminUploads.tsx
+++ b/frontend/src/pages/admin/AdminUploads.tsx
@@ -10,6 +10,7 @@ import '../Admin.css';
 
 export default function AdminUploads() {
   useDocumentTitle(t('admin.uploadManagement'));
+  const addToast = useToastStore((s) => s.addToast);
   const [refreshKey, setRefreshKey] = useState(0);
   const refresh = () => setRefreshKey(k => k + 1);
 
@@ -34,10 +35,10 @@ export default function AdminUploads() {
     if (!window.confirm(t('common.deleteConfirm'))) return;
     try {
       await api.deleteUpload(id);
-      useToastStore().addToast('success', t('common.deleteSuccess'));
+      addToast('success', t('common.deleteSuccess'));
       refresh();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 

--- a/frontend/src/pages/admin/AdminUsers.tsx
+++ b/frontend/src/pages/admin/AdminUsers.tsx
@@ -10,6 +10,7 @@ import '../Admin.css';
 
 export default function AdminUsers() {
   useDocumentTitle(t('admin.userManagement'));
+  const addToast = useToastStore((s) => s.addToast);
   const [refreshKey, setRefreshKey] = useState(0);
   const refresh = () => setRefreshKey(k => k + 1);
 
@@ -55,10 +56,10 @@ export default function AdminUsers() {
   const handleRoleChange = async (userId: number, newRole: string) => {
     try {
       await api.updateUserRole(userId, newRole);
-      useToastStore().addToast('success', t('admin.roleUpdated'));
+      addToast('success', t('admin.roleUpdated'));
       refresh();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 
@@ -71,11 +72,11 @@ export default function AdminUsers() {
     try {
       await api.updateUserPermissions(userId, userPermissions);
       setEditingPermissions(null);
-      useToastStore().addToast('success', t('admin.permissionsUpdated'));
+      addToast('success', t('admin.permissionsUpdated'));
       refresh();
     } catch (e: any) {
       console.error('Failed to update permissions:', e);
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 
@@ -88,10 +89,10 @@ export default function AdminUsers() {
   const handleToggleBan = async (userId: number, currentlyBanned: boolean) => {
     try {
       await api.setUserBanned(userId, !currentlyBanned);
-      useToastStore().addToast('success', t('common.success'));
+      addToast('success', t('common.success'));
       refresh();
     } catch (e: any) {
-      useToastStore().addToast('error', e.message || t('common.error'));
+      addToast('error', e.message || t('common.error'));
     }
   };
 

--- a/frontend/src/store/settings.ts
+++ b/frontend/src/store/settings.ts
@@ -44,6 +44,7 @@ interface SettingsState {
   getAIEnabled: () => boolean;
   getAIChatEnabled: () => boolean;
   getAICompletionEnabled: () => boolean;
+  getCaptchaSubmitEnabled: () => boolean;
   getAdsConfig: () => {
     clientId: string;
     enabled: boolean;
@@ -117,6 +118,11 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
   getAICompletionEnabled: () => {
     const { settings } = get();
     return settings.ai_completion_enabled !== 'false';
+  },
+
+  getCaptchaSubmitEnabled: () => {
+    const { settings } = get();
+    return settings.captcha_enabled !== 'false' && settings.captcha_submit === 'true';
   },
 
   getAdsConfig: () => {


### PR DESCRIPTION
- 扩展 submitCode API 支持验证码字段
- ProblemDetail 条件渲染验证码组件，修复 settings 响应式订阅
- 批量修复 22 个文件中 useToastStore().addToast 的 hook 误用 (React #321)
- 修复 verbatimModuleSyntax type-only import