### PR TITLE
feat: 合并 default/luogu/hydro 三种 UI 主题方案，删除 luogu-style 分支

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 这是一个基于 Cloudflare Workers 的在线判题系统，覆盖题目管理、用户认证、提交评测、竞赛、讨论、题单、后台管理与可选广告位配置。
 
-> **UI 变体**：本仓库提供两套前端视觉风格——`main` 分支为默认风格，[`luogu-style`](https://github.com/wanwusangzhigit/eoj/tree/luogu-style) 分支为洛谷风格完整复刻（50px 蓝粉渐变顶栏 + 240px 左侧边栏双栏布局、9 级难度色板、3-4px 小圆角扁平设计、浅色默认支持暗色切换，覆盖 20+ 页面）。详见该分支 README 的「Luogu 风格 UI 特性」章节。
+> **UI 主题**：本仓库提供三种前端视觉风格，可通过 `frontend/config.yaml` 中的 `site.theme` 字段切换：
+> - **`default`**（默认）— 暗色为主，大圆角（10px），靛蓝渐变强调色，全宽导航栏
+> - **`luogu`** — 洛谷风格复刻，50px 蓝粉渐变顶栏 + 240px 左侧边栏双栏布局，9 级难度色板，3-4px 小圆角扁平设计
+> - **`hydro`** — HydroOJ 风格，蓝色主调 `#5f9fd6`，完全扁平（border-radius: 0），极简设计，浅灰背景
 
 
 ## 技术栈

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 这是一个基于 Cloudflare Workers 的在线判题系统，覆盖题目管理、用户认证、提交评测、竞赛、讨论、题单、后台管理与可选广告位配置。
 
+> **UI 变体**：本仓库提供两套前端视觉风格——`main` 分支为默认风格，[`luogu-style`](https://github.com/wanwusangzhigit/eoj/tree/luogu-style) 分支为洛谷风格完整复刻（50px 蓝粉渐变顶栏 + 240px 左侧边栏双栏布局、9 级难度色板、3-4px 小圆角扁平设计、浅色默认支持暗色切换，覆盖 20+ 页面）。详见该分支 README 的「Luogu 风格 UI 特性」章节。
+
 
 ## 技术栈
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "db:migrate": "wrangler d1 migrations apply DB --remote",
+    "db:migrate:remote": "wrangler d1 migrations apply DB --remote",
     "db:migrate:local": "wrangler d1 migrations apply DB --local",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },

--- a/frontend/config.yaml
+++ b/frontend/config.yaml
@@ -4,6 +4,7 @@ site:
   description: "Online Judge"
   icon: "default"
   favicon: "/favicon.svg"
+  theme: "default"          # "default" / "luogu" / "hydro"，控制 UI 配色方案
 
 footer:
   enabled: true

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -1,4 +1,355 @@
-.header {
+/* ═══════════════════════════════════════════════════
+   Default Theme  — 主分支默认风格
+   ═══════════════════════════════════════════════════ */
+[data-theme-style="default"] .header.header-default {
+  background: rgba(10, 11, 15, 0.85);
+  backdrop-filter: var(--backdrop-blur);
+  -webkit-backdrop-filter: var(--backdrop-blur);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme-style="default"][data-theme="light"] .header.header-default {
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+}
+
+[data-theme-style="default"] .header-default .header-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 0 20px;
+  height: 60px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+[data-theme-style="default"] .header-default .header-logo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 20px;
+  font-weight: 800;
+  color: var(--text-primary);
+  text-decoration: none;
+  transition: transform var(--transition);
+}
+
+[data-theme-style="default"] .header-default .header-logo:hover {
+  transform: scale(1.02);
+}
+
+[data-theme-style="default"] .header-default .header-logo span {
+  background: linear-gradient(135deg, var(--accent), #8b5cf6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+[data-theme-style="default"] .header-default .header-logo-img {
+  width: 28px;
+  height: 28px;
+  object-fit: contain;
+  border-radius: 8px;
+}
+
+[data-theme-style="default"] .header-default .header-nav {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+[data-theme-style="default"] .header-default .header-nav::-webkit-scrollbar {
+  display: none;
+}
+
+[data-theme-style="default"] .header-default .nav-links {
+  display: flex;
+  gap: 4px;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+[data-theme-style="default"] .header-default .nav-link {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border-radius: var(--radius);
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 500;
+  transition: all var(--transition);
+  text-decoration: none;
+  flex-shrink: 0;
+  position: relative;
+}
+
+[data-theme-style="default"] .header-default .nav-link:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  text-decoration: none;
+}
+
+[data-theme-style="default"] .header-default .nav-link.active {
+  color: var(--accent);
+  background: var(--accent-light);
+  font-weight: 600;
+}
+
+[data-theme-style="default"] .header-default .nav-link.active::after {
+  content: '';
+  position: absolute;
+  bottom: 2px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 16px;
+  height: 3px;
+  background: var(--accent);
+  border-radius: 2px;
+}
+
+[data-theme-style="default"] .header-default .header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+[data-theme-style="default"] .header-default .user-menu {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+[data-theme-style="default"] .header-default .user-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  transition: all var(--transition);
+  border: 1px solid transparent;
+}
+
+[data-theme-style="default"] .header-default .user-info:hover {
+  background: var(--bg-tertiary);
+  border-color: var(--border);
+  text-decoration: none;
+}
+
+[data-theme-style="default"] .header-default .user-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  transition: border-color var(--transition);
+}
+
+[data-theme-style="default"] .header-default .user-info:hover .user-avatar {
+  border-color: var(--accent);
+}
+
+[data-theme-style="default"] .header-default .user-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+[data-theme-style="default"] .header-default .btn-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border-radius: var(--radius);
+  transition: all var(--transition);
+  border: 1px solid var(--border);
+}
+
+[data-theme-style="default"] .header-default .btn-icon:hover {
+  background: var(--border);
+  color: var(--error);
+  border-color: var(--error);
+}
+
+[data-theme-style="default"] .header-default .mobile-menu-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-radius: var(--radius);
+  cursor: pointer;
+  border: 1px solid var(--border);
+  transition: all var(--transition);
+}
+
+[data-theme-style="default"] .header-default .mobile-menu-btn:hover {
+  background: var(--border);
+}
+
+[data-theme-style="default"] .header-default .mobile-nav {
+  display: none;
+  flex-direction: column;
+  position: absolute;
+  top: 60px;
+  left: 0;
+  right: 0;
+  background: rgba(10, 11, 15, 0.95);
+  backdrop-filter: var(--backdrop-blur);
+  -webkit-backdrop-filter: var(--backdrop-blur);
+  border-bottom: 1px solid var(--border);
+  padding: 16px 20px;
+  gap: 6px;
+  z-index: 99;
+  animation: slideDown 0.25s ease-out;
+}
+
+[data-theme-style="default"][data-theme="light"] .header-default .mobile-nav {
+  background: rgba(255, 255, 255, 0.98);
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+[data-theme-style="default"] .header-default .theme-toggle-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: none;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--transition);
+  border: 1px solid var(--border);
+}
+
+[data-theme-style="default"] .header-default .theme-toggle-btn:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
+[data-theme-style="default"] .header-default .header-msg-btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--transition);
+  text-decoration: none;
+}
+
+[data-theme-style="default"] .header-default .header-msg-btn:hover {
+  background: var(--border);
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+[data-theme-style="default"] .header-default .msg-unread-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #fe2c55;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid var(--bg);
+}
+
+[data-theme-style="default"] .header-default .nav-unread-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 6px;
+  background: #fe2c55;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+}
+
+@media (max-width: 768px) {
+  [data-theme-style="default"] .header-default .header-nav {
+    display: none;
+  }
+
+  [data-theme-style="default"] .header-default .mobile-menu-btn {
+    display: flex;
+  }
+
+  [data-theme-style="default"] .header-default .mobile-nav {
+    display: flex;
+  }
+
+  [data-theme-style="default"] .header-default .header-inner {
+    position: relative;
+    padding: 0 16px;
+  }
+
+  [data-theme-style="default"] .header-default .user-name {
+    display: none;
+  }
+
+  [data-theme-style="default"] .header-default .header-logo span {
+    font-size: 18px;
+  }
+}
+
+@media (max-width: 480px) {
+  [data-theme-style="default"] .header-default .header-inner {
+    height: 56px;
+    gap: 12px;
+  }
+
+  [data-theme-style="default"] .header-default .mobile-nav {
+    top: 56px;
+  }
+}
+
+/* ═══════════════════════════════════════════════════
+   Luogu Theme  — 洛谷风格复刻
+   ═══════════════════════════════════════════════════ */
+:root .header.header-luogu,
+[data-theme-style="luogu"] .header.header-luogu {
   height: 50px;
   background: var(--header-gradient);
   position: sticky;
@@ -7,7 +358,8 @@
   flex-shrink: 0;
 }
 
-.header-inner {
+:root .header-luogu .header-inner,
+[data-theme-style="luogu"] .header-luogu .header-inner {
   height: 50px;
   max-width: 1400px;
   margin: 0 auto;
@@ -17,7 +369,8 @@
   gap: 12px;
 }
 
-.header-menu-btn {
+:root .header-luogu .header-menu-btn,
+[data-theme-style="luogu"] .header-luogu .header-menu-btn {
   display: none;
   align-items: center;
   justify-content: center;
@@ -31,11 +384,13 @@
   transition: background var(--transition-fast);
 }
 
-.header-menu-btn:hover {
+:root .header-luogu .header-menu-btn:hover,
+[data-theme-style="luogu"] .header-luogu .header-menu-btn:hover {
   background: rgba(255, 255, 255, 0.2);
 }
 
-.header-logo {
+:root .header-luogu .header-logo,
+[data-theme-style="luogu"] .header-luogu .header-logo {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -47,24 +402,28 @@
   transition: opacity var(--transition-fast);
 }
 
-.header-logo:hover {
+:root .header-luogu .header-logo:hover,
+[data-theme-style="luogu"] .header-luogu .header-logo:hover {
   opacity: 0.9;
   text-decoration: none;
   color: #fff;
 }
 
-.header-logo span {
+:root .header-luogu .header-logo span,
+[data-theme-style="luogu"] .header-luogu .header-logo span {
   color: #fff;
 }
 
-.header-logo-img {
+:root .header-luogu .header-logo-img,
+[data-theme-style="luogu"] .header-luogu .header-logo-img {
   width: 24px;
   height: 24px;
   object-fit: contain;
   border-radius: 4px;
 }
 
-.header-search {
+:root .header-luogu .header-search,
+[data-theme-style="luogu"] .header-luogu .header-search {
   flex: 1;
   max-width: 400px;
   display: flex;
@@ -76,12 +435,14 @@
   height: 30px;
 }
 
-.header-search svg {
+:root .header-luogu .header-search svg,
+[data-theme-style="luogu"] .header-luogu .header-search svg {
   color: rgba(255, 255, 255, 0.8);
   flex-shrink: 0;
 }
 
-.header-search input {
+:root .header-luogu .header-search input,
+[data-theme-style="luogu"] .header-luogu .header-search input {
   background: transparent;
   border: none;
   outline: none;
@@ -92,18 +453,21 @@
   min-width: 0;
 }
 
-.header-search input::placeholder {
+:root .header-luogu .header-search input::placeholder,
+[data-theme-style="luogu"] .header-luogu .header-search input::placeholder {
   color: rgba(255, 255, 255, 0.7);
 }
 
-.header-actions {
+:root .header-luogu .header-actions,
+[data-theme-style="luogu"] .header-luogu .header-actions {
   display: flex;
   align-items: center;
   gap: 4px;
   margin-left: auto;
 }
 
-.header-action-btn {
+:root .header-luogu .header-action-btn,
+[data-theme-style="luogu"] .header-luogu .header-action-btn {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -119,13 +483,15 @@
   position: relative;
 }
 
-.header-action-btn:hover {
+:root .header-luogu .header-action-btn:hover,
+[data-theme-style="luogu"] .header-luogu .header-action-btn:hover {
   background: rgba(255, 255, 255, 0.2);
   color: #fff;
   text-decoration: none;
 }
 
-.header-badge {
+:root .header-luogu .header-badge,
+[data-theme-style="luogu"] .header-luogu .header-badge {
   position: absolute;
   top: -2px;
   right: -2px;
@@ -144,13 +510,15 @@
   line-height: 1;
 }
 
-.user-menu {
+:root .header-luogu .user-menu,
+[data-theme-style="luogu"] .header-luogu .user-menu {
   display: flex;
   align-items: center;
   gap: 4px;
 }
 
-.user-info {
+:root .header-luogu .user-info,
+[data-theme-style="luogu"] .header-luogu .user-info {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -161,13 +529,15 @@
   color: #fff;
 }
 
-.user-info:hover {
+:root .header-luogu .user-info:hover,
+[data-theme-style="luogu"] .header-luogu .user-info:hover {
   background: rgba(255, 255, 255, 0.2);
   text-decoration: none;
   color: #fff;
 }
 
-.user-avatar {
+:root .header-luogu .user-avatar,
+[data-theme-style="luogu"] .header-luogu .user-avatar {
   width: 28px;
   height: 28px;
   border-radius: 50%;
@@ -175,13 +545,15 @@
   object-fit: cover;
 }
 
-.user-name {
+:root .header-luogu .user-name,
+[data-theme-style="luogu"] .header-luogu .user-name {
   font-size: 13px;
   font-weight: 500;
   color: #fff;
 }
 
-.header-login-btn {
+:root .header-luogu .header-login-btn,
+[data-theme-style="luogu"] .header-luogu .header-login-btn {
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -196,30 +568,323 @@
   transition: opacity var(--transition-fast);
 }
 
-.header-login-btn:hover {
+:root .header-luogu .header-login-btn:hover,
+[data-theme-style="luogu"] .header-luogu .header-login-btn:hover {
   opacity: 0.9;
   text-decoration: none;
   color: var(--accent);
 }
 
 @media (max-width: 768px) {
-  .header-menu-btn {
+  :root .header-luogu .header-menu-btn,
+  [data-theme-style="luogu"] .header-luogu .header-menu-btn {
     display: inline-flex;
   }
-  .header-search {
+
+  :root .header-luogu .header-search,
+  [data-theme-style="luogu"] .header-luogu .header-search {
     display: none;
   }
-  .user-name {
+
+  :root .header-luogu .user-name,
+  [data-theme-style="luogu"] .header-luogu .user-name {
     display: none;
   }
-  .header-logo span {
+
+  :root .header-luogu .header-logo span,
+  [data-theme-style="luogu"] .header-luogu .header-logo span {
     font-size: 16px;
   }
 }
 
 @media (max-width: 480px) {
-  .header-inner {
+  :root .header-luogu .header-inner,
+  [data-theme-style="luogu"] .header-luogu .header-inner {
     padding: 0 12px;
     gap: 8px;
+  }
+}
+
+/* ═══════════════════════════════════════════════════
+   Hydro Theme  — HydroOJ 风格头部
+   ═══════════════════════════════════════════════════ */
+[data-theme-style="hydro"] .header.header-hydro {
+  height: 45px;
+  background: var(--header-bg, #ffffff);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  flex-shrink: 0;
+}
+
+[data-theme-style="hydro"] .header-hydro .header-inner {
+  height: 45px;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+[data-theme-style="hydro"] .header-hydro .header-logo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-decoration: none;
+  flex-shrink: 0;
+  transition: opacity var(--transition-fast);
+}
+
+[data-theme-style="hydro"] .header-hydro .header-logo:hover {
+  opacity: 0.8;
+  text-decoration: none;
+  color: var(--text-primary);
+}
+
+[data-theme-style="hydro"] .header-hydro .header-logo span {
+  color: var(--text-primary);
+}
+
+[data-theme-style="hydro"] .header-hydro .header-logo-img {
+  width: 22px;
+  height: 22px;
+  object-fit: contain;
+}
+
+[data-theme-style="hydro"] .header-hydro .header-nav {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+  height: 100%;
+}
+
+[data-theme-style="hydro"] .header-hydro .header-nav::-webkit-scrollbar {
+  display: none;
+}
+
+[data-theme-style="hydro"] .header-hydro .nav-links {
+  display: flex;
+  gap: 0;
+  flex-wrap: nowrap;
+  white-space: nowrap;
+  height: 100%;
+}
+
+[data-theme-style="hydro"] .header-hydro .nav-link {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 16px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  font-weight: 400;
+  transition: all var(--transition-fast);
+  text-decoration: none;
+  flex-shrink: 0;
+  position: relative;
+  border-top: 3px solid transparent;
+  height: 100%;
+}
+
+[data-theme-style="hydro"] .header-hydro .nav-link:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  text-decoration: none;
+  border-top-color: var(--accent);
+}
+
+[data-theme-style="hydro"] .header-hydro .nav-link.active {
+  color: var(--nav-active-color, var(--secondary-color, #ed5f82));
+  font-weight: 500;
+  border-top-color: var(--nav-active-color, var(--secondary-color, #ed5f82));
+}
+
+[data-theme-style="hydro"] .header-hydro .header-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+[data-theme-style="hydro"] .header-hydro .user-menu {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+[data-theme-style="hydro"] .header-hydro .user-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  padding: 4px 10px;
+  transition: background var(--transition-fast);
+  color: var(--text-primary);
+}
+
+[data-theme-style="hydro"] .header-hydro .user-info:hover {
+  background: var(--bg-tertiary);
+  text-decoration: none;
+  color: var(--text-primary);
+}
+
+[data-theme-style="hydro"] .header-hydro .user-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  object-fit: cover;
+}
+
+[data-theme-style="hydro"] .header-hydro .user-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+[data-theme-style="hydro"] .header-hydro .header-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid transparent;
+  border-radius: 0;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  text-decoration: none;
+  position: relative;
+}
+
+[data-theme-style="hydro"] .header-hydro .header-action-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+[data-theme-style="hydro"] .header-hydro .header-login-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 14px;
+  background: var(--accent);
+  color: #fff;
+  border: 1px solid var(--accent);
+  font-size: 13px;
+  font-weight: 400;
+  text-decoration: none;
+  transition: background var(--transition-fast);
+}
+
+[data-theme-style="hydro"] .header-hydro .header-login-btn:hover {
+  background: var(--accent-hover);
+  text-decoration: none;
+  color: #fff;
+}
+
+[data-theme-style="hydro"] .header-hydro .header-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  background: var(--error);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+[data-theme-style="hydro"] .header-hydro .mobile-menu-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+[data-theme-style="hydro"] .header-hydro .mobile-menu-btn:hover {
+  background: var(--bg-tertiary);
+}
+
+[data-theme-style="hydro"] .header-hydro .mobile-nav {
+  display: none;
+  flex-direction: column;
+  position: absolute;
+  top: 45px;
+  left: 0;
+  right: 0;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+  padding: 8px 0;
+  z-index: 99;
+  animation: slideDown 0.2s ease-out;
+  box-shadow: var(--shadow-md);
+}
+
+[data-theme-style="hydro"] .header-hydro .mobile-nav .nav-link {
+  padding: 10px 16px;
+  height: auto;
+  border-top: none;
+  border-left: 3px solid transparent;
+}
+
+[data-theme-style="hydro"] .header-hydro .mobile-nav .nav-link.active {
+  border-left-color: var(--nav-active-color, var(--secondary-color, #ed5f82));
+  border-top-color: transparent;
+  background: var(--bg-tertiary);
+}
+
+[data-theme-style="hydro"] .header-hydro .nav-unread-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 6px;
+  background: var(--error);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+}
+
+@media (max-width: 768px) {
+  [data-theme-style="hydro"] .header-hydro .header-nav {
+    display: none;
+  }
+
+  [data-theme-style="hydro"] .header-hydro .mobile-menu-btn {
+    display: flex;
+  }
+
+  [data-theme-style="hydro"] .header-hydro .mobile-nav {
+    display: flex;
+  }
+
+  [data-theme-style="hydro"] .header-hydro .header-inner {
+    position: relative;
+  }
+
+  [data-theme-style="hydro"] .header-hydro .user-name {
+    display: none;
   }
 }

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -1,342 +1,225 @@
 .header {
-  background: rgba(10, 11, 15, 0.85);
-  backdrop-filter: var(--backdrop-blur);
-  -webkit-backdrop-filter: var(--backdrop-blur);
-  border-bottom: 1px solid var(--border);
+  height: 50px;
+  background: var(--header-gradient);
   position: sticky;
   top: 0;
   z-index: 100;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-}
-
-[data-theme="light"] .header {
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+  flex-shrink: 0;
 }
 
 .header-inner {
+  height: 50px;
   max-width: 1400px;
   margin: 0 auto;
-  padding: 0 20px;
-  height: 60px;
+  padding: 0 16px;
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 12px;
+}
+
+.header-menu-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  color: #fff;
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: background var(--transition-fast);
+}
+
+.header-menu-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 .header-logo {
   display: flex;
   align-items: center;
-  gap: 10px;
-  font-size: 20px;
-  font-weight: 800;
-  color: var(--text-primary);
+  gap: 8px;
+  font-size: 18px;
+  font-weight: 600;
+  color: #fff;
   text-decoration: none;
-  transition: transform var(--transition);
+  flex-shrink: 0;
+  transition: opacity var(--transition-fast);
 }
 
 .header-logo:hover {
-  transform: scale(1.02);
+  opacity: 0.9;
+  text-decoration: none;
+  color: #fff;
 }
 
 .header-logo span {
-  background: linear-gradient(135deg, var(--accent), #8b5cf6);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: #fff;
 }
 
 .header-logo-img {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   object-fit: contain;
-  border-radius: 8px;
+  border-radius: 4px;
 }
 
-.header-nav {
-  display: flex;
+.header-search {
   flex: 1;
-  min-width: 0;
-  overflow-x: auto;
-  scrollbar-width: none;
-}
-
-.header-nav::-webkit-scrollbar {
-  display: none;
-}
-
-.nav-links {
-  display: flex;
-  gap: 4px;
-  flex-wrap: nowrap;
-  white-space: nowrap;
-}
-
-.nav-link {
+  max-width: 400px;
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 14px;
+  background: rgba(255, 255, 255, 0.2);
   border-radius: var(--radius);
-  color: var(--text-secondary);
-  font-size: 14px;
-  font-weight: 500;
-  transition: all var(--transition);
-  text-decoration: none;
+  padding: 4px 10px;
+  height: 30px;
+}
+
+.header-search svg {
+  color: rgba(255, 255, 255, 0.8);
   flex-shrink: 0;
-  position: relative;
 }
 
-.nav-link:hover {
-  color: var(--text-primary);
-  background: var(--bg-tertiary);
+.header-search input {
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #fff;
+  flex: 1;
+  font-size: 13px;
+  font-family: inherit;
+  min-width: 0;
 }
 
-.nav-link.active {
-  color: var(--accent);
-  background: var(--accent-light);
-  font-weight: 600;
-}
-
-.nav-link.active::after {
-  content: '';
-  position: absolute;
-  bottom: 2px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 16px;
-  height: 3px;
-  background: var(--accent);
-  border-radius: 2px;
+.header-search input::placeholder {
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.header-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  color: #fff;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+  text-decoration: none;
+  position: relative;
+}
+
+.header-action-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+  text-decoration: none;
+}
+
+.header-badge {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  background: var(--error);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--bg-secondary);
+  line-height: 1;
 }
 
 .user-menu {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 4px;
 }
 
 .user-info {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   text-decoration: none;
-  padding: 8px 12px;
+  padding: 4px 8px;
   border-radius: var(--radius);
-  transition: all var(--transition);
-  border: 1px solid transparent;
+  transition: background var(--transition-fast);
+  color: #fff;
 }
 
 .user-info:hover {
-  background: var(--bg-tertiary);
-  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.2);
+  text-decoration: none;
+  color: #fff;
 }
 
 .user-avatar {
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   border-radius: 50%;
-  border: 2px solid var(--border);
-  transition: border-color var(--transition);
-}
-
-.user-info:hover .user-avatar {
-  border-color: var(--accent);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  object-fit: cover;
 }
 
 .user-name {
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-primary);
-}
-
-.btn-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
-  border: none;
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  border-radius: var(--radius);
-  transition: all var(--transition);
-  border: 1px solid var(--border);
-}
-
-.btn-icon:hover {
-  background: var(--border);
-  color: var(--error);
-  border-color: var(--error);
-}
-
-.mobile-menu-btn {
-  display: none;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border: none;
-  background: var(--bg-tertiary);
-  color: var(--text-primary);
-  border-radius: var(--radius);
-  cursor: pointer;
-  border: 1px solid var(--border);
-  transition: all var(--transition);
-}
-
-.mobile-menu-btn:hover {
-  background: var(--border);
-}
-
-.mobile-nav {
-  display: none;
-  flex-direction: column;
-  position: absolute;
-  top: 60px;
-  left: 0;
-  right: 0;
-  background: rgba(10, 11, 15, 0.95);
-  backdrop-filter: var(--backdrop-blur);
-  -webkit-backdrop-filter: var(--backdrop-blur);
-  border-bottom: 1px solid var(--border);
-  padding: 16px 20px;
-  gap: 6px;
-  z-index: 99;
-  animation: slideDown 0.25s ease-out;
-}
-
-[data-theme="light"] .mobile-nav {
-  background: rgba(255, 255, 255, 0.98);
-}
-
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.theme-toggle-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border: none;
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: all var(--transition);
-  border: 1px solid var(--border);
-}
-
-.theme-toggle-btn:hover {
-  background: var(--border);
-  color: var(--text-primary);
-}
-
-/* Messages icon button in header */
-.header-msg-btn {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  cursor: pointer;
-  transition: all var(--transition);
-  text-decoration: none;
-}
-
-.header-msg-btn:hover {
-  background: var(--border);
-  color: var(--text-primary);
-}
-
-.msg-unread-badge {
-  position: absolute;
-  top: -4px;
-  right: -4px;
-  background: #fe2c55;
+  font-size: 13px;
+  font-weight: 500;
   color: #fff;
-  font-size: 10px;
-  font-weight: 700;
-  min-width: 18px;
-  height: 18px;
-  padding: 0 5px;
-  border-radius: 9px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 2px solid var(--bg);
 }
 
-/* Inline unread pill in nav-link */
-.nav-unread-pill {
+.header-login-btn {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  margin-left: 6px;
-  background: #fe2c55;
-  color: #fff;
-  font-size: 10px;
-  font-weight: 700;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 4px;
-  border-radius: 8px;
+  gap: 4px;
+  padding: 5px 12px;
+  background: #fff;
+  color: var(--accent);
+  border: none;
+  border-radius: var(--radius);
+  font-size: 13px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: opacity var(--transition-fast);
+}
+
+.header-login-btn:hover {
+  opacity: 0.9;
+  text-decoration: none;
+  color: var(--accent);
 }
 
 @media (max-width: 768px) {
-  .header-nav {
+  .header-menu-btn {
+    display: inline-flex;
+  }
+  .header-search {
     display: none;
   }
-
-  .mobile-menu-btn {
-    display: flex;
-  }
-
-  .mobile-nav {
-    display: flex;
-  }
-
-  .header-inner {
-    position: relative;
-    padding: 0 16px;
-  }
-
   .user-name {
     display: none;
   }
-
   .header-logo span {
-    font-size: 18px;
+    font-size: 16px;
   }
 }
 
 @media (max-width: 480px) {
   .header-inner {
-    height: 56px;
-    gap: 12px;
-  }
-
-  .mobile-nav {
-    top: 56px;
+    padding: 0 12px;
+    gap: 8px;
   }
 }

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,45 +1,22 @@
-import { useState, useEffect } from 'react';
-import { NavLink, useNavigate, Link } from 'react-router-dom';
+import { useNavigate, Link, NavLink } from 'react-router-dom';
 import { useAuthStore } from '../store/auth';
 import { useThemeStore } from '../store/theme';
-import { useSettingsStore } from '../store/settings';
 import { t } from '../i18n';
-import { api } from '../api/client';
-import { LogOut, User, Shield, Code2, ListChecks, Trophy, Target, Heart, Menu, X, Sun, Moon, Swords, Ticket, BookOpen, MessageSquare, Home, FolderOpen, Bot, GraduationCap, Users, PenSquare, Mail } from 'lucide-react';
+import { LogOut, User, Code2, Menu, Sun, Moon, Mail, Search } from 'lucide-react';
 import NotificationBell from './NotificationBell';
-import { usePermissions } from '../hooks/usePermissions';
 import { useSiteConfig } from '../hooks/useSiteConfig';
 import './Header.css';
-export default function Header() {
+
+interface HeaderProps {
+  onMenuClick: () => void;
+  unreadMsg: number;
+}
+
+export default function Header({ onMenuClick, unreadMsg }: HeaderProps) {
   const { user, logout } = useAuthStore();
-  const perms = usePermissions();
   const config = useSiteConfig();
   const { theme, toggleTheme } = useThemeStore();
-  const getImageUploadEnabled = useSettingsStore((s) => s.getImageUploadEnabled);
-  const getUploadEnabled = useSettingsStore((s) => s.getUploadEnabled);
   const navigate = useNavigate();
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [unreadMsg, setUnreadMsg] = useState(0);
-
-  const showMyFiles = user && (getImageUploadEnabled() || getUploadEnabled() || perms.canManageUploads);
-
-  const getAIEnabled = useSettingsStore((s) => s.getAIEnabled);
-  const getAIChatEnabled = useSettingsStore((s) => s.getAIChatEnabled);
-  const showAI = user && (getAIEnabled() || perms.hasAllPermissions) && getAIChatEnabled();
-
-  // Poll unread messages count
-  useEffect(() => {
-    if (!user) return;
-    const fetchUnread = async () => {
-      try {
-        const data = await api.getUnreadMessagesCount();
-        setUnreadMsg(data.count || 0);
-      } catch { /* ignore */ }
-    };
-    fetchUnread();
-    const timer = setInterval(fetchUnread, 30000);
-    return () => clearInterval(timer);
-  }, [user]);
 
   const handleLogout = () => {
     logout();
@@ -49,184 +26,44 @@ export default function Header() {
   return (
     <header className="header">
       <div className="header-inner">
+        <button
+          className="header-menu-btn"
+          onClick={onMenuClick}
+          aria-label={t('nav.openMenu')}
+        >
+          <Menu size={20} />
+        </button>
+
         <NavLink to="/" className="header-logo">
-          {config.site.icon === 'default' ? <Code2 size={24} /> : <img src={config.site.icon} alt={config.site.name} className="header-logo-img" />}
+          {config.site.icon === 'default' ? <Code2 size={22} /> : <img src={config.site.icon} alt={config.site.name} className="header-logo-img" />}
           <span>{config.site.name}</span>
         </NavLink>
 
-        <nav className="header-nav">
-          <div className="nav-links">
-            <NavLink to="/" end className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-              <Home size={16} />
-              {t('nav.home')}
-            </NavLink>
-            <NavLink to="/problems" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-              <Target size={16} />
-              {t('nav.problems')}
-            </NavLink>
-            <NavLink to="/contests" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-              <Swords size={16} />
-              {t('nav.contests')}
-            </NavLink>
-            <NavLink to="/rankings" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-              <Trophy size={16} />
-              {t('nav.rankings')}
-            </NavLink>
-            <NavLink to="/lists" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-              <BookOpen size={16} />
-              {t('nav.lists')}
-            </NavLink>
-            <NavLink to="/training" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-              <GraduationCap size={16} />
-              {t('nav.training')}
-            </NavLink>
-            <NavLink to="/discussions/all" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-              <MessageSquare size={16} />
-              {t('nav.discussions')}
-            </NavLink>
-            <NavLink to="/blogs" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-              <PenSquare size={16} />
-              {t('nav.blogs')}
-            </NavLink>
-            {user && (
-              <NavLink to="/teams" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-                <Users size={16} />
-                {t('nav.teams')}
-              </NavLink>
-            )}
-            {user && (
-              <NavLink to="/messages" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-                <Mail size={16} />
-                {t('nav.messages')}
-                {unreadMsg > 0 && <span className="nav-unread-pill">{unreadMsg > 99 ? '99+' : unreadMsg}</span>}
-              </NavLink>
-            )}
-            {user && (
-              <NavLink to="/submissions" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-                <ListChecks size={16} />
-                {t('nav.submissions')}
-              </NavLink>
-            )}
-            {user && (
-              <NavLink to="/tickets" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-                <Ticket size={16} />
-                {t('nav.tickets')}
-              </NavLink>
-            )}
-            {user && (
-              <NavLink to="/favorites" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-                <Heart size={16} />
-                {t('nav.favorites')}
-              </NavLink>
-            )}
-            {showMyFiles && (
-              <NavLink to="/my-files" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-                <FolderOpen size={16} />
-                {t('common.myFiles')}
-              </NavLink>
-            )}
-            {showAI && (
-              <NavLink to="/ai" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-                <Bot size={16} />
-                {t('nav.ai')}
-              </NavLink>
-            )}
-            {perms.hasAllPermissions && (
-              <NavLink to="/admin/dashboard" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
-                <Shield size={16} />
-                {t('nav.admin')}
-              </NavLink>
-            )}
-          </div>
-        </nav>
-
-        <button className="mobile-menu-btn" onClick={() => setMobileMenuOpen(!mobileMenuOpen)} aria-label={mobileMenuOpen ? t('nav.closeMenu') : t('nav.openMenu')}>
-          {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
-        </button>
-
-        {mobileMenuOpen ? (
-          <div className="mobile-nav">
-            <NavLink to="/" end className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-              <Home size={16} /> {t('nav.home')}
-            </NavLink>
-            <NavLink to="/problems" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-              <Target size={16} /> {t('nav.problems')}
-            </NavLink>
-            <NavLink to="/contests" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-              <Swords size={16} /> {t('nav.contests')}
-            </NavLink>
-            <NavLink to="/rankings" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-              <Trophy size={16} /> {t('nav.rankings')}
-            </NavLink>
-            <NavLink to="/lists" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-              <BookOpen size={16} /> {t('nav.lists')}
-            </NavLink>
-            <NavLink to="/training" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-              <GraduationCap size={16} /> {t('nav.training')}
-            </NavLink>
-            <NavLink to="/discussions/all" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-              <MessageSquare size={16} /> {t('nav.discussions')}
-            </NavLink>
-            <NavLink to="/blogs" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-              <PenSquare size={16} /> {t('nav.blogs')}
-            </NavLink>
-            {user && (
-              <NavLink to="/teams" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-                <Users size={16} /> {t('nav.teams')}
-              </NavLink>
-            )}
-            {user && (
-              <NavLink to="/messages" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-                <Mail size={16} /> {t('nav.messages')}
-                {unreadMsg > 0 && <span className="nav-unread-pill">{unreadMsg > 99 ? '99+' : unreadMsg}</span>}
-              </NavLink>
-            )}
-            {user && (
-              <NavLink to="/submissions" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-                <ListChecks size={16} /> {t('nav.submissions')}
-              </NavLink>
-            )}
-            {user && (
-              <NavLink to="/tickets" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-                <Ticket size={16} /> {t('nav.tickets')}
-              </NavLink>
-            )}
-            {user && (
-              <NavLink to="/favorites" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-                <Heart size={16} /> {t('nav.favorites')}
-              </NavLink>
-            )}
-            {showMyFiles && (
-              <NavLink to="/my-files" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-                <FolderOpen size={16} /> {t('common.myFiles')}
-              </NavLink>
-            )}
-            {showAI && (
-              <NavLink to="/ai" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-                <Bot size={16} /> {t('nav.ai')}
-              </NavLink>
-            )}
-            {perms.hasAllPermissions && (
-              <NavLink to="/admin/dashboard" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
-                <Shield size={16} /> {t('nav.admin')}
-              </NavLink>
-            )}
-          </div>
-        ) : null}
+        <form
+          className="header-search"
+          onSubmit={(e) => {
+            e.preventDefault();
+            const q = (new FormData(e.currentTarget).get('q') as string || '').trim();
+            if (q) navigate(`/problems?search=${encodeURIComponent(q)}`);
+          }}
+        >
+          <Search size={14} />
+          <input name="q" placeholder={t('common.search')} />
+        </form>
 
         <div className="header-actions">
           <button
-            className="theme-toggle-btn"
+            className="header-action-btn"
             onClick={toggleTheme}
             title={theme === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
             aria-label={theme === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
           >
-            {theme === 'dark' ? <Sun size={18} /> : <Moon size={18} />}
+            {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
           </button>
           {user && (
-            <Link to="/messages" className="header-msg-btn" title={t('nav.messages')} aria-label={t('nav.messages')}>
-              <Mail size={18} />
-              {unreadMsg > 0 && <span className="msg-unread-badge">{unreadMsg > 99 ? '99+' : unreadMsg}</span>}
+            <Link to="/messages" className="header-action-btn" title={t('nav.messages')} aria-label={t('nav.messages')}>
+              <Mail size={16} />
+              {unreadMsg > 0 && <span className="header-badge">{unreadMsg > 99 ? '99+' : unreadMsg}</span>}
             </Link>
           )}
           {user && <NotificationBell />}
@@ -238,13 +75,13 @@ export default function Header() {
                 )}
                 <span className="user-name">{user.username}</span>
               </Link>
-              <button className="btn-icon" onClick={handleLogout} title={t('nav.logout')} aria-label={t('nav.logout')}>
+              <button className="header-action-btn" onClick={handleLogout} title={t('nav.logout')} aria-label={t('nav.logout')}>
                 <LogOut size={16} />
               </button>
             </div>
           ) : (
-            <Link to="/login" className="btn btn-primary btn-sm">
-              <User size={16} />
+            <Link to="/login" className="header-login-btn">
+              <User size={14} />
               {t('nav.login')}
             </Link>
           )}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,91 +1,320 @@
-import { useNavigate, Link, NavLink } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { NavLink, useNavigate, Link } from 'react-router-dom';
 import { useAuthStore } from '../store/auth';
 import { useThemeStore } from '../store/theme';
+import { useSettingsStore } from '../store/settings';
 import { t } from '../i18n';
-import { LogOut, User, Code2, Menu, Sun, Moon, Mail, Search } from 'lucide-react';
-import NotificationBell from './NotificationBell';
+import { api } from '../api/client';
 import { useSiteConfig } from '../hooks/useSiteConfig';
+import {
+  LogOut, User, Shield, Code2, ListChecks, Trophy, Target, Heart,
+  Menu, X, Sun, Moon, Swords, Ticket, BookOpen, MessageSquare, Home,
+  FolderOpen, Bot, GraduationCap, Users, PenSquare, Mail, Search,
+} from 'lucide-react';
+import NotificationBell from './NotificationBell';
+import { usePermissions } from '../hooks/usePermissions';
 import './Header.css';
 
 interface HeaderProps {
-  onMenuClick: () => void;
-  unreadMsg: number;
+  onMenuClick?: () => void;
+  unreadMsg?: number;
 }
 
-export default function Header({ onMenuClick, unreadMsg }: HeaderProps) {
+export default function Header({ onMenuClick, unreadMsg = 0 }: HeaderProps) {
   const { user, logout } = useAuthStore();
+  const perms = usePermissions();
   const config = useSiteConfig();
   const { theme, toggleTheme } = useThemeStore();
+  const getImageUploadEnabled = useSettingsStore((s) => s.getImageUploadEnabled);
+  const getUploadEnabled = useSettingsStore((s) => s.getUploadEnabled);
   const navigate = useNavigate();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const isLuogu = config.site.theme === 'luogu';
+  const isHydro = config.site.theme === 'hydro';
+  const headerStyleClass = isHydro ? 'header-hydro' : 'header-default';
+
+  const showMyFiles = user && (getImageUploadEnabled() || getUploadEnabled() || perms.canManageUploads);
+  const getAIEnabled = useSettingsStore((s) => s.getAIEnabled);
+  const getAIChatEnabled = useSettingsStore((s) => s.getAIChatEnabled);
+  const showAI = user && (getAIEnabled() || perms.hasAllPermissions) && getAIChatEnabled();
+
+  // Poll unread messages count (only for default theme, luogu theme gets it from Layout)
+  const [localUnread, setLocalUnread] = useState(0);
+  const effectiveUnread = isLuogu ? (unreadMsg || 0) : localUnread;
+
+  useEffect(() => {
+    if (!user || isLuogu) return;
+    const fetchUnread = async () => {
+      try {
+        const data = await api.getUnreadMessagesCount();
+        setLocalUnread(data.count || 0);
+      } catch { /* ignore */ }
+    };
+    fetchUnread();
+    const timer = setInterval(fetchUnread, 30000);
+    return () => clearInterval(timer);
+  }, [user, isLuogu]);
 
   const handleLogout = () => {
     logout();
     navigate('/');
   };
 
-  return (
-    <header className="header">
-      <div className="header-inner">
-        <button
-          className="header-menu-btn"
-          onClick={onMenuClick}
-          aria-label={t('nav.openMenu')}
-        >
-          <Menu size={20} />
-        </button>
+  /* ═══════════════════════════════════════════════════
+     Luogu-style header: simplified, hamburger + sidebar
+     ═══════════════════════════════════════════════════ */
+  if (isLuogu) {
+    return (
+      <header className="header header-luogu">
+        <div className="header-inner">
+          <button
+            className="header-menu-btn"
+            onClick={onMenuClick}
+            aria-label={t('nav.openMenu')}
+          >
+            <Menu size={20} />
+          </button>
 
+          <NavLink to="/" className="header-logo">
+            {config.site.icon === 'default' ? <Code2 size={22} /> : <img src={config.site.icon} alt={config.site.name} className="header-logo-img" />}
+            <span>{config.site.name}</span>
+          </NavLink>
+
+          <form
+            className="header-search"
+            onSubmit={(e) => {
+              e.preventDefault();
+              const q = (new FormData(e.currentTarget).get('q') as string || '').trim();
+              if (q) navigate(`/problems?search=${encodeURIComponent(q)}`);
+            }}
+          >
+            <Search size={14} />
+            <input name="q" placeholder={t('common.search')} />
+          </form>
+
+          <div className="header-actions">
+            <button
+              className="header-action-btn"
+              onClick={toggleTheme}
+              title={theme === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
+              aria-label={theme === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
+            >
+              {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
+            </button>
+            {user && (
+              <Link to="/messages" className="header-action-btn" title={t('nav.messages')} aria-label={t('nav.messages')}>
+                <Mail size={16} />
+                {effectiveUnread > 0 && <span className="header-badge">{effectiveUnread > 99 ? '99+' : effectiveUnread}</span>}
+              </Link>
+            )}
+            {user && <NotificationBell />}
+            {user ? (
+              <div className="user-menu">
+                <Link to="/profile" className="user-info">
+                  {user.avatar_url && (
+                    <img src={user.avatar_url} alt={user.username} className="user-avatar" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                  )}
+                  <span className="user-name">{user.username}</span>
+                </Link>
+                <button className="header-action-btn" onClick={handleLogout} title={t('nav.logout')} aria-label={t('nav.logout')}>
+                  <LogOut size={16} />
+                </button>
+              </div>
+            ) : (
+              <Link to="/login" className="header-login-btn">
+                <User size={14} />
+                {t('nav.login')}
+              </Link>
+            )}
+          </div>
+        </div>
+      </header>
+    );
+  }
+
+  /* ═══════════════════════════════════════════════════
+     Default-style header: full horizontal nav
+     ═══════════════════════════════════════════════════ */
+  return (
+    <header className={`header ${headerStyleClass}`}>
+      <div className="header-inner">
         <NavLink to="/" className="header-logo">
-          {config.site.icon === 'default' ? <Code2 size={22} /> : <img src={config.site.icon} alt={config.site.name} className="header-logo-img" />}
+          {config.site.icon === 'default' ? <Code2 size={24} /> : <img src={config.site.icon} alt={config.site.name} className="header-logo-img" />}
           <span>{config.site.name}</span>
         </NavLink>
 
-        <form
-          className="header-search"
-          onSubmit={(e) => {
-            e.preventDefault();
-            const q = (new FormData(e.currentTarget).get('q') as string || '').trim();
-            if (q) navigate(`/problems?search=${encodeURIComponent(q)}`);
-          }}
-        >
-          <Search size={14} />
-          <input name="q" placeholder={t('common.search')} />
-        </form>
+        <nav className="header-nav">
+          <div className="nav-links">
+            <NavLink to="/" end className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+              <Home size={16} />{t('nav.home')}
+            </NavLink>
+            <NavLink to="/problems" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+              <Target size={16} />{t('nav.problems')}
+            </NavLink>
+            <NavLink to="/contests" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+              <Swords size={16} />{t('nav.contests')}
+            </NavLink>
+            <NavLink to="/rankings" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+              <Trophy size={16} />{t('nav.rankings')}
+            </NavLink>
+            <NavLink to="/lists" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+              <BookOpen size={16} />{t('nav.lists')}
+            </NavLink>
+            <NavLink to="/training" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+              <GraduationCap size={16} />{t('nav.training')}
+            </NavLink>
+            <NavLink to="/discussions/all" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+              <MessageSquare size={16} />{t('nav.discussions')}
+            </NavLink>
+            <NavLink to="/blogs" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+              <PenSquare size={16} />{t('nav.blogs')}
+            </NavLink>
+            {user && (
+              <NavLink to="/teams" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+                <Users size={16} />{t('nav.teams')}
+              </NavLink>
+            )}
+            {user && (
+              <NavLink to="/messages" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+                <Mail size={16} />{t('nav.messages')}
+                {effectiveUnread > 0 && <span className="nav-unread-pill">{effectiveUnread > 99 ? '99+' : effectiveUnread}</span>}
+              </NavLink>
+            )}
+            {user && (
+              <NavLink to="/submissions" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+                <ListChecks size={16} />{t('nav.submissions')}
+              </NavLink>
+            )}
+            {user && (
+              <NavLink to="/tickets" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+                <Ticket size={16} />{t('nav.tickets')}
+              </NavLink>
+            )}
+            {user && (
+              <NavLink to="/favorites" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+                <Heart size={16} />{t('nav.favorites')}
+              </NavLink>
+            )}
+            {showMyFiles && (
+              <NavLink to="/my-files" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+                <FolderOpen size={16} />{t('common.myFiles')}
+              </NavLink>
+            )}
+            {showAI && (
+              <NavLink to="/ai" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+                <Bot size={16} />{t('nav.ai')}
+              </NavLink>
+            )}
+            {perms.hasAllPermissions && (
+              <NavLink to="/admin/dashboard" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'}>
+                <Shield size={16} />{t('nav.admin')}
+              </NavLink>
+            )}
+          </div>
+        </nav>
+
+        <button className="mobile-menu-btn" onClick={() => setMobileMenuOpen(!mobileMenuOpen)} aria-label={mobileMenuOpen ? t('nav.closeMenu') : t('nav.openMenu')}>
+          {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
+        </button>
 
         <div className="header-actions">
-          <button
-            className="header-action-btn"
-            onClick={toggleTheme}
-            title={theme === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
-            aria-label={theme === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}
-          >
+          <button className="theme-toggle-btn" onClick={toggleTheme} title={theme === 'dark' ? t('nav.lightMode') : t('nav.darkMode')} aria-label={theme === 'dark' ? t('nav.lightMode') : t('nav.darkMode')}>
             {theme === 'dark' ? <Sun size={16} /> : <Moon size={16} />}
           </button>
-          {user && (
-            <Link to="/messages" className="header-action-btn" title={t('nav.messages')} aria-label={t('nav.messages')}>
-              <Mail size={16} />
-              {unreadMsg > 0 && <span className="header-badge">{unreadMsg > 99 ? '99+' : unreadMsg}</span>}
-            </Link>
-          )}
-          {user && <NotificationBell />}
           {user ? (
-            <div className="user-menu">
-              <Link to="/profile" className="user-info">
-                {user.avatar_url && (
-                  <img src={user.avatar_url} alt={user.username} className="user-avatar" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
-                )}
-                <span className="user-name">{user.username}</span>
+            <>
+              <Link to="/messages" className="header-msg-btn" title={t('nav.messages')} aria-label={t('nav.messages')}>
+                <Mail size={16} />
+                {effectiveUnread > 0 && <span className="msg-unread-badge">{effectiveUnread > 99 ? '99+' : effectiveUnread}</span>}
               </Link>
-              <button className="header-action-btn" onClick={handleLogout} title={t('nav.logout')} aria-label={t('nav.logout')}>
-                <LogOut size={16} />
-              </button>
-            </div>
+              <NotificationBell />
+              <div className="user-menu">
+                <Link to="/profile" className="user-info">
+                  {user.avatar_url && <img src={user.avatar_url} alt={user.username} className="user-avatar" />}
+                  <span className="user-name">{user.username}</span>
+                </Link>
+                <button className="btn-icon" onClick={handleLogout} title={t('nav.logout')} aria-label={t('nav.logout')}>
+                  <LogOut size={16} />
+                </button>
+              </div>
+            </>
           ) : (
-            <Link to="/login" className="header-login-btn">
+            <Link to="/login" className="btn btn-primary btn-sm">
               <User size={14} />
               {t('nav.login')}
             </Link>
           )}
         </div>
+
+        {mobileMenuOpen && (
+          <div className="mobile-nav">
+            <NavLink to="/" end className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+              <Home size={16} /> {t('nav.home')}
+            </NavLink>
+            <NavLink to="/problems" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+              <Target size={16} /> {t('nav.problems')}
+            </NavLink>
+            <NavLink to="/contests" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+              <Swords size={16} /> {t('nav.contests')}
+            </NavLink>
+            <NavLink to="/rankings" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+              <Trophy size={16} /> {t('nav.rankings')}
+            </NavLink>
+            <NavLink to="/lists" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+              <BookOpen size={16} /> {t('nav.lists')}
+            </NavLink>
+            <NavLink to="/training" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+              <GraduationCap size={16} /> {t('nav.training')}
+            </NavLink>
+            <NavLink to="/discussions/all" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+              <MessageSquare size={16} /> {t('nav.discussions')}
+            </NavLink>
+            <NavLink to="/blogs" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+              <PenSquare size={16} /> {t('nav.blogs')}
+            </NavLink>
+            {user && (
+              <NavLink to="/teams" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+                <Users size={16} /> {t('nav.teams')}
+              </NavLink>
+            )}
+            {user && (
+              <NavLink to="/messages" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+                <Mail size={16} /> {t('nav.messages')}
+                {effectiveUnread > 0 && <span className="nav-unread-pill">{effectiveUnread > 99 ? '99+' : effectiveUnread}</span>}
+              </NavLink>
+            )}
+            {user && (
+              <NavLink to="/submissions" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+                <ListChecks size={16} /> {t('nav.submissions')}
+              </NavLink>
+            )}
+            {user && (
+              <NavLink to="/tickets" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+                <Ticket size={16} /> {t('nav.tickets')}
+              </NavLink>
+            )}
+            {user && (
+              <NavLink to="/favorites" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+                <Heart size={16} /> {t('nav.favorites')}
+              </NavLink>
+            )}
+            {showMyFiles && (
+              <NavLink to="/my-files" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+                <FolderOpen size={16} /> {t('common.myFiles')}
+              </NavLink>
+            )}
+            {showAI && (
+              <NavLink to="/ai" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+                <Bot size={16} /> {t('nav.ai')}
+              </NavLink>
+            )}
+            {perms.hasAllPermissions && (
+              <NavLink to="/admin/dashboard" className={({ isActive }) => isActive ? 'nav-link active' : 'nav-link'} onClick={() => setMobileMenuOpen(false)}>
+                <Shield size={16} /> {t('nav.admin')}
+              </NavLink>
+            )}
+          </div>
+        )}
       </div>
     </header>
   );

--- a/frontend/src/components/Layout.css
+++ b/frontend/src/components/Layout.css
@@ -6,59 +6,45 @@
   position: relative;
 }
 
+.layout-body {
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+  min-height: 0;
+}
+
 .main-content {
   flex: 1;
-  max-width: 1400px;
-  width: 100%;
-  margin: 0 auto;
-  padding: 32px 24px;
-  animation: fadeInUp 0.4s ease-out;
+  min-width: 0;
+  padding: 16px 20px;
+  animation: fadeInUp 0.25s ease-out;
 }
 
 @media (max-width: 768px) {
   .main-content {
-    padding: 24px 16px;
+    padding: 12px;
   }
 }
 
 .site-footer {
   border-top: 1px solid var(--border);
-  background: rgba(10, 11, 15, 0.8);
-  backdrop-filter: var(--backdrop-blur);
-  -webkit-backdrop-filter: var(--backdrop-blur);
-  padding: 32px 24px;
+  background: var(--bg-secondary);
+  padding: 16px 20px;
   margin-top: auto;
-  margin-top: calc(auto + 48px);
-  position: relative;
-  overflow: hidden;
-}
-
-.site-footer::before {
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent, var(--accent-glow), transparent);
-}
-
-[data-theme="light"] .site-footer {
-  background: rgba(255, 255, 255, 0.9);
 }
 
 .footer-inner {
-  max-width: 1400px;
+  max-width: 1200px;
   margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 24px;
+  gap: 16px;
   flex-wrap: wrap;
 }
 
 .footer-text {
-  font-size: 13px;
+  font-size: 12px;
   color: var(--text-secondary);
   display: flex;
   align-items: center;
@@ -76,37 +62,19 @@
 
 .footer-links {
   display: flex;
-  gap: 16px;
+  gap: 12px;
   flex-wrap: wrap;
 }
 
 .footer-links a {
-  font-size: 13px;
+  font-size: 12px;
   color: var(--text-secondary);
   text-decoration: none;
-  transition: all var(--transition);
-  padding: 8px 12px;
-  border-radius: var(--radius);
-  position: relative;
-}
-
-.footer-links a::after {
-  content: '';
-  position: absolute;
-  bottom: 4px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 0;
-  height: 2px;
-  background: var(--accent);
-  transition: width var(--transition);
+  transition: color var(--transition-fast);
+  padding: 2px 4px;
 }
 
 .footer-links a:hover {
   color: var(--accent);
-  background: var(--accent-light);
-}
-
-.footer-links a:hover::after {
-  width: 60%;
+  text-decoration: none;
 }

--- a/frontend/src/components/Layout.css
+++ b/frontend/src/components/Layout.css
@@ -1,4 +1,7 @@
-.layout {
+/* ═══════════════════════════════════════════════════
+   Default Theme  — 主分支默认风格
+   ═══════════════════════════════════════════════════ */
+[data-theme-style="default"] .layout {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -6,34 +9,149 @@
   position: relative;
 }
 
-.layout-body {
+[data-theme-style="default"] .main-content {
+  flex: 1;
+  max-width: 1400px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 32px 24px;
+  animation: fadeInUp 0.4s ease-out;
+}
+
+[data-theme-style="default"] .site-footer {
+  border-top: 1px solid var(--border);
+  background: rgba(10, 11, 15, 0.8);
+  backdrop-filter: var(--backdrop-blur);
+  -webkit-backdrop-filter: var(--backdrop-blur);
+  padding: 32px 24px;
+  margin-top: auto;
+  position: relative;
+  overflow: hidden;
+}
+
+[data-theme-style="default"] .site-footer::before {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--accent-glow), transparent);
+}
+
+[data-theme-style="default"][data-theme="light"] .site-footer {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+[data-theme-style="default"] .footer-inner {
+  max-width: 1400px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+[data-theme-style="default"] .footer-text {
+  font-size: 13px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+[data-theme-style="default"] .footer-text-multi {
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+[data-theme-style="default"] .footer-custom-text {
+  white-space: pre-wrap;
+}
+
+[data-theme-style="default"] .footer-links {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+[data-theme-style="default"] .footer-links a {
+  font-size: 13px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: all var(--transition);
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  position: relative;
+}
+
+[data-theme-style="default"] .footer-links a::after {
+  content: '';
+  position: absolute;
+  bottom: 4px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 0;
+  height: 2px;
+  background: var(--accent);
+  transition: width var(--transition);
+}
+
+[data-theme-style="default"] .footer-links a:hover {
+  color: var(--accent);
+  background: var(--accent-light);
+  text-decoration: none;
+}
+
+[data-theme-style="default"] .footer-links a:hover::after {
+  width: 60%;
+}
+
+@media (max-width: 768px) {
+  [data-theme-style="default"] .main-content {
+    padding: 24px 16px;
+  }
+}
+
+/* ═══════════════════════════════════════════════════
+   Luogu Theme  — 洛谷风格复刻
+   ═══════════════════════════════════════════════════ */
+:root .layout,
+[data-theme-style="luogu"] .layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  position: relative;
+}
+
+:root .layout-body,
+[data-theme-style="luogu"] .layout-body {
   flex: 1;
   display: flex;
   align-items: flex-start;
   min-height: 0;
 }
 
-.main-content {
+:root .main-content,
+[data-theme-style="luogu"] .main-content {
   flex: 1;
   min-width: 0;
   padding: 16px 20px;
   animation: fadeInUp 0.25s ease-out;
 }
 
-@media (max-width: 768px) {
-  .main-content {
-    padding: 12px;
-  }
-}
-
-.site-footer {
+:root .site-footer,
+[data-theme-style="luogu"] .site-footer {
   border-top: 1px solid var(--border);
   background: var(--bg-secondary);
   padding: 16px 20px;
   margin-top: auto;
 }
 
-.footer-inner {
+:root .footer-inner,
+[data-theme-style="luogu"] .footer-inner {
   max-width: 1200px;
   margin: 0 auto;
   display: flex;
@@ -43,7 +161,8 @@
   flex-wrap: wrap;
 }
 
-.footer-text {
+:root .footer-text,
+[data-theme-style="luogu"] .footer-text {
   font-size: 12px;
   color: var(--text-secondary);
   display: flex;
@@ -51,22 +170,26 @@
   gap: 8px;
 }
 
-.footer-text-multi {
+:root .footer-text-multi,
+[data-theme-style="luogu"] .footer-text-multi {
   flex-wrap: wrap;
   gap: 12px;
 }
 
-.footer-custom-text {
+:root .footer-custom-text,
+[data-theme-style="luogu"] .footer-custom-text {
   white-space: pre-wrap;
 }
 
-.footer-links {
+:root .footer-links,
+[data-theme-style="luogu"] .footer-links {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
 }
 
-.footer-links a {
+:root .footer-links a,
+[data-theme-style="luogu"] .footer-links a {
   font-size: 12px;
   color: var(--text-secondary);
   text-decoration: none;
@@ -74,7 +197,94 @@
   padding: 2px 4px;
 }
 
-.footer-links a:hover {
+:root .footer-links a:hover,
+[data-theme-style="luogu"] .footer-links a:hover {
   color: var(--accent);
   text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  :root .main-content,
+  [data-theme-style="luogu"] .main-content {
+    padding: 12px;
+  }
+}
+
+/* ═══════════════════════════════════════════════════
+   Hydro Theme  — HydroOJ 风格布局
+   ═══════════════════════════════════════════════════ */
+[data-theme-style="hydro"] .layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  position: relative;
+}
+
+[data-theme-style="hydro"] .main-content {
+  flex: 1;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 24px 16px;
+  animation: fadeInUp 0.25s ease-out;
+}
+
+[data-theme-style="hydro"] .site-footer {
+  border-top: 1px solid var(--border);
+  background: var(--bg-secondary);
+  padding: 20px 16px;
+  margin-top: auto;
+}
+
+[data-theme-style="hydro"] .footer-inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+[data-theme-style="hydro"] .footer-text {
+  font-size: 13px;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+[data-theme-style="hydro"] .footer-text-multi {
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+[data-theme-style="hydro"] .footer-custom-text {
+  white-space: pre-wrap;
+}
+
+[data-theme-style="hydro"] .footer-links {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+[data-theme-style="hydro"] .footer-links a {
+  font-size: 13px;
+  color: var(--text-secondary);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+  padding: 4px 6px;
+}
+
+[data-theme-style="hydro"] .footer-links a:hover {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+@media (max-width: 768px) {
+  [data-theme-style="hydro"] .main-content {
+    padding: 16px 12px;
+  }
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,15 +1,17 @@
 import type { ReactNode } from 'react';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Header from './Header';
+import Sidebar from './Sidebar';
 import Toast from './Toast';
 import { useThemeStore } from '../store/theme';
 import { useSettingsStore } from '../store/settings';
+import { useAuthStore } from '../store/auth';
 import { useSiteConfig } from '../hooks/useSiteConfig';
+import { api } from '../api/client';
 import { t } from '../i18n';
 import './Layout.css';
 
-// 页脚内置的站内链接（独立于 site-config 中的外部 links）
 const FOOTER_INTERNAL_LINKS = [
   { to: '/privacy', label: 'privacy.title' },
   { to: '/terms', label: 'terms.title' },
@@ -20,6 +22,9 @@ export default function Layout({ children }: { children: ReactNode }) {
   const { theme } = useThemeStore();
   const config = useSiteConfig();
   const fetchSettings = useSettingsStore((s) => s.fetchSettings);
+  const { user } = useAuthStore();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [unreadMsg, setUnreadMsg] = useState(0);
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
@@ -29,12 +34,44 @@ export default function Layout({ children }: { children: ReactNode }) {
     fetchSettings();
   }, [fetchSettings]);
 
+  useEffect(() => {
+    if (!user) {
+      setUnreadMsg(0);
+      return;
+    }
+    const fetchUnread = async () => {
+      try {
+        const data = await api.getUnreadMessagesCount();
+        setUnreadMsg(data.count || 0);
+      } catch { /* ignore */ }
+    };
+    fetchUnread();
+    const timer = setInterval(fetchUnread, 30000);
+    return () => clearInterval(timer);
+  }, [user]);
+
   return (
     <div className="layout">
-      <Header />
-      <main className="main-content">
-        {children}
-      </main>
+      <Header
+        onMenuClick={() => setSidebarOpen((v) => !v)}
+        unreadMsg={unreadMsg}
+      />
+      <div className="layout-body">
+        <Sidebar
+          open={sidebarOpen}
+          onClose={() => setSidebarOpen(false)}
+          unreadMsg={unreadMsg}
+        />
+        {sidebarOpen && (
+          <div
+            className="sidebar-mask"
+            onClick={() => setSidebarOpen(false)}
+          />
+        )}
+        <main className="main-content">
+          {children}
+        </main>
+      </div>
       <footer className="site-footer">
         <div className="footer-inner">
           <div className="footer-text footer-text-multi">

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -25,15 +25,18 @@ export default function Layout({ children }: { children: ReactNode }) {
   const { user } = useAuthStore();
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [unreadMsg, setUnreadMsg] = useState(0);
+  const isLuogu = config.site.theme === 'luogu';
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
-  }, [theme]);
+    document.documentElement.setAttribute('data-theme-style', config.site.theme);
+  }, [theme, config.site.theme]);
 
   useEffect(() => {
     fetchSettings();
   }, [fetchSettings]);
 
+  // Poll unread messages (for luogu sidebar + default header)
   useEffect(() => {
     if (!user) {
       setUnreadMsg(0);
@@ -56,22 +59,28 @@ export default function Layout({ children }: { children: ReactNode }) {
         onMenuClick={() => setSidebarOpen((v) => !v)}
         unreadMsg={unreadMsg}
       />
-      <div className="layout-body">
-        <Sidebar
-          open={sidebarOpen}
-          onClose={() => setSidebarOpen(false)}
-          unreadMsg={unreadMsg}
-        />
-        {sidebarOpen && (
-          <div
-            className="sidebar-mask"
-            onClick={() => setSidebarOpen(false)}
+      {isLuogu ? (
+        <div className="layout-body">
+          <Sidebar
+            open={sidebarOpen}
+            onClose={() => setSidebarOpen(false)}
+            unreadMsg={unreadMsg}
           />
-        )}
+          {sidebarOpen && (
+            <div
+              className="sidebar-mask"
+              onClick={() => setSidebarOpen(false)}
+            />
+          )}
+          <main className="main-content">
+            {children}
+          </main>
+        </div>
+      ) : (
         <main className="main-content">
           {children}
         </main>
-      </div>
+      )}
       <footer className="site-footer">
         <div className="footer-inner">
           <div className="footer-text footer-text-multi">

--- a/frontend/src/components/NotificationBell.css
+++ b/frontend/src/components/NotificationBell.css
@@ -1,4 +1,4 @@
-.notification-bell {
+﻿.notification-bell {
   position: relative;
   display: inline-flex;
 }
@@ -131,7 +131,7 @@
 }
 
 .read-indicator {
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
   flex-shrink: 0;
   margin-top: 4px;
 }
@@ -143,7 +143,7 @@
 }
 
 .bell-dropdown-footer a {
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
   font-size: 13px;
   text-decoration: none;
 }

--- a/frontend/src/components/NotificationBell.css
+++ b/frontend/src/components/NotificationBell.css
@@ -1,4 +1,4 @@
-﻿.notification-bell {
+.notification-bell {
   position: relative;
   display: inline-flex;
 }
@@ -19,6 +19,10 @@
 
 .bell-button:hover {
   background: rgba(255, 255, 255, 0.08);
+}
+
+[data-theme-style="hydro"] .bell-button:hover {
+  background: var(--bg-tertiary);
 }
 
 .unread-badge {
@@ -55,6 +59,13 @@
   overflow: hidden;
 }
 
+[data-theme-style="hydro"] .bell-dropdown {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  box-shadow: var(--shadow-lg);
+}
+
 .bell-dropdown-header {
   display: flex;
   align-items: center;
@@ -63,6 +74,10 @@
   border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
   font-weight: 600;
   font-size: 14px;
+}
+
+[data-theme-style="hydro"] .bell-dropdown-header {
+  border-bottom: 1px solid var(--border);
 }
 
 .bell-dropdown-body {
@@ -88,12 +103,24 @@
   transition: background 0.15s;
 }
 
+[data-theme-style="hydro"] .bell-item {
+  border-bottom: 1px solid var(--border-light);
+}
+
 .bell-item:hover {
   background: rgba(255, 255, 255, 0.04);
 }
 
+[data-theme-style="hydro"] .bell-item:hover {
+  background: var(--bg-tertiary);
+}
+
 .bell-item.unread {
   background: rgba(99, 102, 241, 0.06);
+}
+
+[data-theme-style="hydro"] .bell-item.unread {
+  background: var(--accent-light);
 }
 
 .type-dot {
@@ -140,6 +167,10 @@
   padding: 10px 14px;
   border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
   text-align: center;
+}
+
+[data-theme-style="hydro"] .bell-dropdown-footer {
+  border-top: 1px solid var(--border);
 }
 
 .bell-dropdown-footer a {

--- a/frontend/src/components/Sidebar.css
+++ b/frontend/src/components/Sidebar.css
@@ -1,0 +1,156 @@
+.sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  padding: 8px 0;
+  position: sticky;
+  top: 50px;
+  align-self: flex-start;
+  max-height: calc(100vh - 50px);
+  overflow-y: auto;
+}
+
+.sidebar-header {
+  display: none;
+  padding: 4px 12px 8px;
+  justify-content: flex-end;
+}
+
+.sidebar-close {
+  display: none;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius);
+  align-items: center;
+  justify-content: center;
+}
+
+.sidebar-close:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-group {
+  padding: 4px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.sidebar-group:last-child {
+  border-bottom: none;
+}
+
+.sidebar-group-title {
+  padding: 8px 20px 4px;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+}
+
+.sidebar-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 20px;
+  color: var(--text-primary);
+  font-size: 14px;
+  text-decoration: none;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  position: relative;
+  border-left: 3px solid transparent;
+}
+
+.sidebar-link:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.sidebar-link.active {
+  color: var(--accent);
+  background: var(--accent-light);
+  font-weight: 500;
+  border-left-color: var(--accent);
+}
+
+.sidebar-link svg {
+  flex-shrink: 0;
+}
+
+.sidebar-link-label {
+  flex: 1;
+}
+
+.sidebar-badge {
+  margin-left: auto;
+  background: var(--error);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 600;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.sidebar-mask {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .sidebar {
+    position: fixed;
+    top: 50px;
+    left: 0;
+    bottom: 0;
+    z-index: 99;
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    box-shadow: var(--shadow-lg);
+    max-height: calc(100vh - 50px);
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+  }
+
+  .sidebar-header {
+    display: flex;
+  }
+
+  .sidebar-close {
+    display: inline-flex;
+  }
+
+  .sidebar-mask {
+    display: block;
+    position: fixed;
+    top: 50px;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 98;
+    animation: fadeIn 0.2s ease-out;
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,100 @@
+import { NavLink } from 'react-router-dom';
+import { useAuthStore } from '../store/auth';
+import { useSettingsStore } from '../store/settings';
+import { t } from '../i18n';
+import {
+  Home, Target, Swords, Trophy, BookOpen, GraduationCap,
+  MessageSquare, PenSquare, Users, Mail, ListChecks,
+  Ticket, Heart, FolderOpen, Bot, Shield, X,
+} from 'lucide-react';
+import { usePermissions } from '../hooks/usePermissions';
+import './Sidebar.css';
+
+interface SidebarProps {
+  open: boolean;
+  onClose: () => void;
+  unreadMsg: number;
+}
+
+export default function Sidebar({ open, onClose, unreadMsg }: SidebarProps) {
+  const { user } = useAuthStore();
+  const perms = usePermissions();
+  const getImageUploadEnabled = useSettingsStore((s) => s.getImageUploadEnabled);
+  const getUploadEnabled = useSettingsStore((s) => s.getUploadEnabled);
+  const showMyFiles = user && (getImageUploadEnabled() || getUploadEnabled() || perms.canManageUploads);
+
+  const getAIEnabled = useSettingsStore((s) => s.getAIEnabled);
+  const getAIChatEnabled = useSettingsStore((s) => s.getAIChatEnabled);
+  const showAI = user && (getAIEnabled() || perms.hasAllPermissions) && getAIChatEnabled();
+
+  const mainNav = [
+    { to: '/', icon: Home, label: t('nav.home'), end: true },
+    { to: '/problems', icon: Target, label: t('nav.problems') },
+    { to: '/contests', icon: Swords, label: t('nav.contests') },
+    { to: '/rankings', icon: Trophy, label: t('nav.rankings') },
+    { to: '/lists', icon: BookOpen, label: t('nav.lists') },
+    { to: '/training', icon: GraduationCap, label: t('nav.training') },
+    { to: '/discussions/all', icon: MessageSquare, label: t('nav.discussions') },
+    { to: '/blogs', icon: PenSquare, label: t('nav.blogs') },
+  ];
+
+  const userNav = user ? [
+    { to: '/submissions', icon: ListChecks, label: t('nav.submissions') },
+    { to: '/teams', icon: Users, label: t('nav.teams') },
+    { to: '/messages', icon: Mail, label: t('nav.messages'), badge: unreadMsg },
+    { to: '/favorites', icon: Heart, label: t('nav.favorites') },
+    { to: '/tickets', icon: Ticket, label: t('nav.tickets') },
+    ...(showMyFiles ? [{ to: '/my-files', icon: FolderOpen, label: t('common.myFiles') }] : []),
+    ...(showAI ? [{ to: '/ai', icon: Bot, label: t('nav.ai') }] : []),
+  ] : [];
+
+  const adminNav = perms.hasAllPermissions
+    ? [{ to: '/admin/dashboard', icon: Shield, label: t('nav.admin') }]
+    : [];
+
+  const renderLink = (item: { to: string; icon: any; label: string; end?: boolean; badge?: number }, onNavigate?: () => void) => {
+    const Icon = item.icon;
+    return (
+      <NavLink
+        key={item.to}
+        to={item.to}
+        end={item.end}
+        className={({ isActive }) => isActive ? 'sidebar-link active' : 'sidebar-link'}
+        onClick={onNavigate}
+      >
+        <Icon size={16} />
+        <span className="sidebar-link-label">{item.label}</span>
+        {item.badge !== undefined && item.badge > 0 && (
+          <span className="sidebar-badge">{item.badge > 99 ? '99+' : item.badge}</span>
+        )}
+      </NavLink>
+    );
+  };
+
+  return (
+    <aside className={`sidebar${open ? ' open' : ''}`}>
+      <div className="sidebar-header">
+        <button className="sidebar-close" onClick={onClose} aria-label={t('nav.closeMenu')}>
+          <X size={18} />
+        </button>
+      </div>
+      <nav className="sidebar-nav">
+        <div className="sidebar-group">
+          {mainNav.map((item) => renderLink(item, onClose))}
+        </div>
+        {userNav.length > 0 && (
+          <div className="sidebar-group">
+            <div className="sidebar-group-title">{t('nav.personal')}</div>
+            {userNav.map((item) => renderLink(item, onClose))}
+          </div>
+        )}
+        {adminNav.length > 0 && (
+          <div className="sidebar-group">
+            <div className="sidebar-group-title">{t('nav.adminGroup')}</div>
+            {adminNav.map((item) => renderLink(item, onClose))}
+          </div>
+        )}
+      </nav>
+    </aside>
+  );
+}

--- a/frontend/src/components/Toast.css
+++ b/frontend/src/components/Toast.css
@@ -28,12 +28,27 @@
   border-left: 3px solid var(--success);
 }
 
+[data-theme-style="hydro"] .toast.toast-success {
+  border-left: none;
+  border-top: 3px solid var(--success);
+}
+
 .toast.toast-error {
   border-left: 3px solid var(--error);
 }
 
+[data-theme-style="hydro"] .toast.toast-error {
+  border-left: none;
+  border-top: 3px solid var(--error);
+}
+
 .toast.toast-info {
   border-left: 3px solid var(--info);
+}
+
+[data-theme-style="hydro"] .toast.toast-info {
+  border-left: none;
+  border-top: 3px solid var(--info);
 }
 
 .toast-icon {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -70,12 +70,27 @@ fn main() {
 `,
 };
 
-export const DIFFICULTIES = ['Easy', 'Medium', 'Hard'];
+export const DIFFICULTIES = [
+  '暂无难度', '入门', '普及-', '普及',
+  '提高', '提高+', '省选-', '省选',
+  'NOI', 'NOI+', 'CTSC',
+];
 
 export const DIFFICULTY_COLORS: Record<string, string> = {
-  Easy: '#4ade80',
-  Medium: '#fbbf24',
-  Hard: '#ef4444',
+  '暂无难度': 'var(--diff-none)',
+  '入门': 'var(--diff-easy)',
+  '普及-': 'var(--diff-easy-mid)',
+  '普及': 'var(--diff-mid)',
+  '提高': 'var(--diff-hard)',
+  '提高+': 'var(--diff-hard-plus)',
+  '省选-': 'var(--diff-province)',
+  '省选': 'var(--diff-province-plus)',
+  'NOI': 'var(--diff-noi)',
+  'NOI+': 'var(--diff-noi)',
+  'CTSC': 'var(--diff-noi)',
+  'Easy': 'var(--diff-mid)',
+  'Medium': 'var(--diff-hard)',
+  'Hard': 'var(--diff-easy)',
 };
 
 export const LANGUAGE_EXTENSIONS: Record<string, any> = {

--- a/frontend/src/hooks/useSiteConfig.ts
+++ b/frontend/src/hooks/useSiteConfig.ts
@@ -9,6 +9,7 @@ const defaults: SiteConfig = {
     description: 'Online Judge',
     icon: 'default',
     favicon: '/favicon.svg',
+    theme: 'default',
   },
   footer: {
     enabled: true,

--- a/frontend/src/i18n/en.ts
+++ b/frontend/src/i18n/en.ts
@@ -27,6 +27,8 @@ const en: Translations = {
     notifications: 'Notifications',
     closeMenu: 'Close menu',
     openMenu: 'Open menu',
+    personal: 'Personal',
+    adminGroup: 'Admin',
   },
   common: {
     search: 'Search',

--- a/frontend/src/i18n/zh.ts
+++ b/frontend/src/i18n/zh.ts
@@ -26,6 +26,8 @@ const zh = {
     notifications: '通知',
     closeMenu: '关闭菜单',
     openMenu: '打开菜单',
+    personal: '个人',
+    adminGroup: '管理',
   },
   // Common
   common: {

--- a/frontend/src/pages/AIChat.css
+++ b/frontend/src/pages/AIChat.css
@@ -51,7 +51,7 @@
   padding: 3px 10px;
   background: var(--accent-light);
   color: var(--accent);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.2px;
@@ -702,7 +702,7 @@
 .ai-prompt-chip {
   padding: 7px 14px;
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: var(--radius);
   background: var(--bg-card);
   color: var(--text-secondary);
   font-size: 13px;

--- a/frontend/src/pages/Admin.css
+++ b/frontend/src/pages/Admin.css
@@ -2044,3 +2044,37 @@
 .ads-help ol li {
   margin-bottom: 4px;
 }
+
+/* ═══════════════════════════════════════════════════
+   Hydro Theme  — 覆盖 luogu 特定样式
+   ═══════════════════════════════════════════════════ */
+[data-theme-style="hydro"] .stat-card::before {
+  display: none;
+}
+
+[data-theme-style="hydro"] .stat-card:hover {
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-card);
+}
+
+[data-theme-style="hydro"] .stat-card:hover::before {
+  opacity: 0;
+}
+
+[data-theme-style="hydro"] .ads-intro {
+  border-left: none;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+}
+
+[data-theme-style="hydro"] .admin-sidebar-inner::before {
+  display: none;
+}
+
+[data-theme-style="hydro"] .admin-sidebar-link::before {
+  display: none;
+}
+
+[data-theme-style="hydro"] .admin-sidebar-link.active::before {
+  display: none;
+}

--- a/frontend/src/pages/Admin.css
+++ b/frontend/src/pages/Admin.css
@@ -1,4 +1,4 @@
-﻿.admin-page {
+.admin-page {
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -214,9 +214,7 @@
 }
 
 .stat-card:hover {
-  border-color: var(--border-hover);
-  box-shadow: var(--shadow-card);
-  transform: translateY(-2px);
+  border-color: var(--accent);
 }
 
 .stat-card:hover::before {
@@ -239,27 +237,27 @@
 }
 
 .stat-icon-wrapper.blue {
-  background: linear-gradient(135deg, var(--info-bg), rgba(59, 130, 246, 0.05));
+  background: var(--info-bg);
   color: var(--info);
 }
 
 .stat-icon-wrapper.green {
-  background: linear-gradient(135deg, var(--success-bg), rgba(34, 197, 94, 0.05));
+  background: var(--success-bg);
   color: var(--success);
 }
 
 .stat-icon-wrapper.purple {
-  background: linear-gradient(135deg, rgba(167, 139, 250, 0.15), rgba(139, 92, 246, 0.05));
-  color: #a78bfa;
+  background: var(--accent-light);
+  color: var(--accent);
 }
 
 .stat-icon-wrapper.orange {
-  background: linear-gradient(135deg, var(--warning-bg), rgba(245, 158, 11, 0.05));
+  background: var(--warning-bg);
   color: var(--warning);
 }
 
 .stat-icon-wrapper.red {
-  background: linear-gradient(135deg, var(--error-bg), rgba(239, 68, 68, 0.05));
+  background: var(--error-bg);
   color: var(--error);
 }
 
@@ -271,10 +269,7 @@
   font-size: 32px;
   font-weight: 700;
   line-height: 1.1;
-  background: linear-gradient(135deg, var(--text-primary), var(--text-secondary));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
 }
 
 .stat-label {
@@ -328,7 +323,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -690,7 +684,6 @@
 .testcase-io label {
   font-size: 11px;
   color: var(--text-muted);
-  text-transform: uppercase;
 }
 
 .testcase-io pre {
@@ -1478,7 +1471,7 @@
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
   overflow: hidden;
 }
 
@@ -1554,7 +1547,7 @@
 }
 
 .visibility-toggle.private {
-  color: var(--text-muted, #888);
+  color: var(--text-muted);
   background: rgba(136, 136, 136, 0.1);
 }
 
@@ -1642,7 +1635,6 @@
   font-weight: 600;
   border: 1px solid;
   border-radius: 10px;
-  text-transform: capitalize;
 }
 
 .link {
@@ -1677,7 +1669,7 @@
   display: inline-flex;
   align-items: center;
   padding: 4px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 500;
   background: var(--bg-tertiary);
@@ -1818,7 +1810,7 @@
   left: 0;
   right: 0;
   height: 2px;
-  background: linear-gradient(90deg, var(--accent), transparent);
+  background: var(--accent);
 }
 
 .admin-sidebar-title {

--- a/frontend/src/pages/Admin.css
+++ b/frontend/src/pages/Admin.css
@@ -1,4 +1,4 @@
-.admin-page {
+﻿.admin-page {
   display: flex;
   flex-direction: column;
   gap: 20px;
@@ -75,8 +75,8 @@
 
 .announcement-preview {
   padding: 12px 16px;
-  background: linear-gradient(135deg, var(--color-primary-alpha, rgba(59,130,246,0.08)), var(--color-info-alpha, rgba(14,165,233,0.08)));
-  border: 1px solid var(--color-primary-alpha, rgba(59,130,246,0.2));
+  background: var(--accent-light);
+  border: 1px solid var(--accent);
   border-radius: var(--radius);
   font-size: 14px;
   line-height: 1.6;
@@ -84,7 +84,7 @@
 }
 
 .announcement-preview a {
-  color: var(--color-primary, #3b82f6);
+  color: var(--accent);
   text-decoration: underline;
 }
 
@@ -208,7 +208,7 @@
   left: 0;
   right: 0;
   height: 3px;
-  background: linear-gradient(90deg, var(--accent), #8b5cf6);
+  background: var(--accent);
   opacity: 0;
   transition: opacity var(--transition);
 }
@@ -1590,7 +1590,7 @@
 }
 
 .msg-row-admin.own-b {
-  border-left: 3px solid var(--accent, #6366f1);
+  border-left: 3px solid var(--accent);
 }
 
 .msg-row-header {

--- a/frontend/src/pages/Blogs.css
+++ b/frontend/src/pages/Blogs.css
@@ -1,4 +1,4 @@
-﻿.blogs-page {
+.blogs-page {
   max-width: 800px;
   margin: 0 auto;
   padding: 24px;
@@ -27,8 +27,8 @@
 .sort-tabs {
   display: flex;
   gap: 4px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   padding: 2px;
 }
@@ -37,7 +37,7 @@
   padding: 4px 12px;
   background: transparent;
   border: none;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   cursor: pointer;
   border-radius: 6px;
   font-size: 13px;
@@ -59,8 +59,8 @@
   flex-direction: column;
   gap: 10px;
   padding: 16px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   text-decoration: none;
   color: inherit;
@@ -69,7 +69,6 @@
 
 .blog-card:hover {
   border-color: var(--accent);
-  transform: translateY(-1px);
 }
 
 .blog-card-header {
@@ -111,7 +110,7 @@
 }
 
 .blog-date {
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .blog-title {
@@ -138,7 +137,7 @@
   display: flex;
   gap: 16px;
   font-size: 12px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .blog-stats span {
@@ -158,22 +157,22 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   text-decoration: none;
   font-size: 13px;
   margin-bottom: 16px;
 }
 
 .blog-article {
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   overflow: hidden;
 }
 
 .article-header {
   padding: 24px;
-  border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-bottom: 1px solid var(--border);
 }
 
 .article-header h1 {
@@ -186,7 +185,7 @@
   align-items: center;
   gap: 8px;
   font-size: 13px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .article-author {
@@ -196,7 +195,7 @@
 }
 
 .meta-sep {
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .draft-badge {
@@ -236,7 +235,7 @@
 
 .article-footer {
   padding: 16px 24px;
-  border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-top: 1px solid var(--border);
 }
 
 .article-actions {
@@ -251,7 +250,7 @@
   gap: 6px;
   background: transparent;
   border: none;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 14px;
   padding: 4px 8px;
@@ -276,8 +275,8 @@
 /* Comments */
 .comments-section {
   margin-top: 24px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   padding: 20px;
 }
@@ -296,8 +295,8 @@
 
 .comment-form textarea {
   padding: 10px 12px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   color: inherit;
   outline: none;
@@ -340,7 +339,7 @@
 
 .comment-time {
   font-size: 11px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .comment-text {
@@ -351,7 +350,7 @@
 .empty-text {
   text-align: center;
   padding: 20px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   font-size: 13px;
 }
 
@@ -383,8 +382,8 @@
 .blog-editor-form input,
 .blog-editor-form textarea {
   padding: 10px 12px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   color: inherit;
   outline: none;
@@ -405,7 +404,7 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .empty-state p {

--- a/frontend/src/pages/Blogs.css
+++ b/frontend/src/pages/Blogs.css
@@ -1,4 +1,4 @@
-.blogs-page {
+﻿.blogs-page {
   max-width: 800px;
   margin: 0 auto;
   padding: 24px;
@@ -44,7 +44,7 @@
 }
 
 .sort-tab.active {
-  background: var(--primary-color, #6366f1);
+  background: var(--accent);
   color: #fff;
 }
 
@@ -68,7 +68,7 @@
 }
 
 .blog-card:hover {
-  border-color: var(--primary-color, #6366f1);
+  border-color: var(--accent);
   transform: translateY(-1px);
 }
 
@@ -91,7 +91,7 @@
 }
 
 .blog-avatar.placeholder {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  background: var(--accent);
   color: #fff;
   display: flex;
   align-items: center;
@@ -129,7 +129,7 @@
 .blog-tag {
   padding: 2px 8px;
   background: rgba(99, 102, 241, 0.12);
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
   border-radius: 4px;
   font-size: 11px;
 }
@@ -190,7 +190,7 @@
 }
 
 .article-author {
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
   text-decoration: none;
   font-weight: 500;
 }
@@ -260,7 +260,7 @@
 }
 
 .action-btn:hover {
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
 }
 
 .action-btn.liked {
@@ -305,7 +305,7 @@
 }
 
 .comment-form textarea:focus {
-  border-color: var(--primary-color, #6366f1);
+  border-color: var(--accent);
 }
 
 .comments-list {
@@ -334,7 +334,7 @@
 
 .comment-author {
   font-weight: 500;
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
   text-decoration: none;
 }
 
@@ -393,7 +393,7 @@
 
 .blog-editor-form input:focus,
 .blog-editor-form textarea:focus {
-  border-color: var(--primary-color, #6366f1);
+  border-color: var(--accent);
 }
 
 .editor-actions {

--- a/frontend/src/pages/ContestDetail.css
+++ b/frontend/src/pages/ContestDetail.css
@@ -83,7 +83,7 @@
 }
 
 .nav-problem-btn.active {
-  background: var(--accent-light, rgba(108, 140, 255, 0.12));
+  background: var(--accent-light);
   color: var(--accent);
 }
 
@@ -226,7 +226,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -283,7 +283,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -329,7 +328,7 @@
   width: 32px;
   height: 32px;
   border-radius: var(--radius);
-  background: var(--accent-light, rgba(108, 140, 255, 0.12));
+  background: var(--accent-light);
   color: var(--accent);
   font-weight: 700;
   font-size: 14px;
@@ -501,7 +500,7 @@
 }
 
 .cell-attempted {
-  background: rgba(108, 140, 255, 0.08);
+  background: var(--accent-light);
   color: var(--accent);
 }
 
@@ -575,7 +574,7 @@
   width: 28px;
   height: 28px;
   border-radius: var(--radius);
-  background: var(--accent-light, rgba(108, 140, 255, 0.12));
+  background: var(--accent-light);
   color: var(--accent);
   font-weight: 700;
   font-size: 13px;
@@ -754,7 +753,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 

--- a/frontend/src/pages/Contests.css
+++ b/frontend/src/pages/Contests.css
@@ -41,7 +41,7 @@
   border: 1px solid var(--border);
   background: var(--bg-card);
   color: var(--text-secondary);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;

--- a/frontend/src/pages/CreateContest.css
+++ b/frontend/src/pages/CreateContest.css
@@ -8,7 +8,7 @@
   background: var(--bg-secondary);
   border-radius: 12px;
   padding: 24px;
-  border: 1px solid var(--border-color, var(--border));
+  border: 1px solid var(--border);
 }
 
 .create-contest-header {
@@ -40,7 +40,7 @@
 .contest-form .form-textarea {
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid var(--border-color, var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-primary);
   color: var(--text-primary);

--- a/frontend/src/pages/CreateProblemList.css
+++ b/frontend/src/pages/CreateProblemList.css
@@ -8,7 +8,7 @@
   background: var(--bg-secondary);
   border-radius: 12px;
   padding: 24px;
-  border: 1px solid var(--border-color, var(--border));
+  border: 1px solid var(--border);
 }
 
 .create-list-header {
@@ -40,7 +40,7 @@
 .list-form .form-textarea {
   width: 100%;
   padding: 10px 12px;
-  border: 1px solid var(--border-color, var(--border));
+  border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-primary);
   color: var(--text-primary);

--- a/frontend/src/pages/DiscussionDetail.css
+++ b/frontend/src/pages/DiscussionDetail.css
@@ -70,7 +70,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -97,7 +97,7 @@
   padding: 3px 10px;
   background: var(--warning-bg);
   color: var(--warning);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }

--- a/frontend/src/pages/Discussions.css
+++ b/frontend/src/pages/Discussions.css
@@ -124,6 +124,11 @@
   border-left: 3px solid var(--warning);
 }
 
+[data-theme-style="hydro"] .discussion-card.pinned {
+  border-left: none;
+  border-top: 2px solid var(--warning);
+}
+
 .discussion-card-stats {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/Discussions.css
+++ b/frontend/src/pages/Discussions.css
@@ -36,7 +36,7 @@
   padding: 4px 12px;
   background: var(--accent-light);
   color: var(--accent);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 13px;
   font-weight: 500;
 }
@@ -78,7 +78,7 @@
   border: 1px solid var(--border);
   background: var(--bg-card);
   color: var(--text-secondary);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
@@ -175,7 +175,7 @@
   padding: 2px 8px;
   background: var(--warning-bg);
   color: var(--warning);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 11px;
   font-weight: 600;
   flex-shrink: 0;
@@ -185,7 +185,7 @@
   display: inline-flex;
   align-items: center;
   padding: 2px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
   flex-shrink: 0;

--- a/frontend/src/pages/Favorites.css
+++ b/frontend/src/pages/Favorites.css
@@ -75,7 +75,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -120,7 +119,7 @@
   display: inline-flex;
   align-items: center;
   padding: 4px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 500;
   background: var(--bg-tertiary);

--- a/frontend/src/pages/FollowList.css
+++ b/frontend/src/pages/FollowList.css
@@ -1,4 +1,4 @@
-.follow-list-page {
+﻿.follow-list-page {
   max-width: 900px;
   margin: 0 auto;
   padding: 24px;
@@ -39,7 +39,7 @@
 }
 
 .follow-card:hover {
-  border-color: var(--primary-color, #6366f1);
+  border-color: var(--accent);
   background: rgba(99, 102, 241, 0.06);
 }
 
@@ -52,7 +52,7 @@
 }
 
 .follow-avatar.placeholder {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  background: var(--accent);
   color: #fff;
   display: flex;
   align-items: center;

--- a/frontend/src/pages/FollowList.css
+++ b/frontend/src/pages/FollowList.css
@@ -1,4 +1,4 @@
-﻿.follow-list-page {
+.follow-list-page {
   max-width: 900px;
   margin: 0 auto;
   padding: 24px;
@@ -30,8 +30,8 @@
   align-items: center;
   gap: 12px;
   padding: 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 10px;
   text-decoration: none;
   color: inherit;
@@ -73,7 +73,7 @@
 
 .follow-bio {
   font-size: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   margin-top: 2px;
   white-space: nowrap;
   overflow: hidden;
@@ -83,5 +83,5 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }

--- a/frontend/src/pages/GlobalDiscussions.css
+++ b/frontend/src/pages/GlobalDiscussions.css
@@ -120,7 +120,7 @@
   padding: 2px 8px;
   background: var(--warning-bg);
   color: var(--warning);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 11px;
   font-weight: 600;
   flex-shrink: 0;
@@ -130,7 +130,7 @@
   display: inline-flex;
   align-items: center;
   padding: 2px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
   flex-shrink: 0;

--- a/frontend/src/pages/GlobalSolutions.css
+++ b/frontend/src/pages/GlobalSolutions.css
@@ -130,7 +130,7 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 11px;
   font-weight: 600;
   background: var(--accent-light);

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -16,6 +16,14 @@
   border-radius: var(--radius-lg);
 }
 
+/* Default & Hydro theme: hero with gradient background */
+[data-theme-style="default"] .home-hero,
+[data-theme-style="hydro"] .home-hero {
+  background: linear-gradient(135deg, var(--accent-light), var(--info-bg));
+  border: 1px solid var(--accent-light);
+  padding: 32px;
+}
+
 .home-hero-left {
   display: flex;
   flex-direction: column;
@@ -27,6 +35,17 @@
   font-weight: 700;
   color: var(--text-primary);
   margin: 0;
+}
+
+/* Default & Hydro: larger gradient title */
+[data-theme-style="default"] .home-title,
+[data-theme-style="hydro"] .home-title {
+  font-size: 28px;
+  font-weight: 800;
+  background: linear-gradient(135deg, var(--accent), var(--info));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .home-date {
@@ -42,11 +61,26 @@
   color: var(--text-secondary);
 }
 
+/* Default & Hydro: larger welcome text */
+[data-theme-style="default"] .home-welcome,
+[data-theme-style="hydro"] .home-welcome {
+  font-size: 15px;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
 .home-stats-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 8px;
   min-width: 320px;
+}
+
+/* Default & Hydro: no min-width on stats grid */
+[data-theme-style="default"] .home-stats-grid,
+[data-theme-style="hydro"] .home-stats-grid {
+  min-width: auto;
+  gap: 10px;
 }
 
 .home-stat-card {
@@ -64,9 +98,22 @@
   transition: all var(--transition, 0.15s);
 }
 
+/* Default & Hydro: stat card uses bg-card */
+[data-theme-style="default"] .home-stat-card,
+[data-theme-style="hydro"] .home-stat-card {
+  background: var(--bg-card);
+}
+
 .home-stat-card:hover {
   border-color: var(--accent);
   color: var(--accent);
+}
+
+/* Default & Hydro: stat card hover changes bg */
+[data-theme-style="default"] .home-stat-card:hover,
+[data-theme-style="hydro"] .home-stat-card:hover {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
 }
 
 .home-stat-card svg:first-child {
@@ -93,6 +140,16 @@
   color: var(--text-primary);
   font-size: 13px;
   line-height: 1.6;
+}
+
+/* Default & Hydro: announcement with gradient bg and full border */
+[data-theme-style="default"] .home-announcement,
+[data-theme-style="hydro"] .home-announcement {
+  border-left: none;
+  background: var(--accent-light);
+  border: 1px solid var(--accent-light);
+  padding: 12px 16px;
+  font-size: 14px;
 }
 
 .home-announcement .announcement-icon {
@@ -350,6 +407,13 @@
   background: var(--bg-tertiary);
 }
 
+/* Default & Hydro: no tertiary bg on card header */
+[data-theme-style="default"] .home-card-header,
+[data-theme-style="hydro"] .home-card-header {
+  background: none;
+  padding: 14px 18px;
+}
+
 .home-card-header h2 {
   display: flex;
   align-items: center;
@@ -372,6 +436,18 @@
   height: 14px;
   background: var(--accent);
   border-radius: 2px;
+}
+
+/* Default & Hydro: no left accent bar on h2 */
+[data-theme-style="default"] .home-card-header h2,
+[data-theme-style="hydro"] .home-card-header h2 {
+  padding-left: 0;
+  font-size: 15px;
+}
+
+[data-theme-style="default"] .home-card-header h2::before,
+[data-theme-style="hydro"] .home-card-header h2::before {
+  display: none;
 }
 
 .home-card-header h2 svg {
@@ -419,6 +495,19 @@
 .home-item:hover {
   background: var(--bg-tertiary);
   border-left-color: var(--accent);
+}
+
+/* Default & Hydro: no left accent bar, larger padding */
+[data-theme-style="default"] .home-item,
+[data-theme-style="hydro"] .home-item {
+  border-left: none;
+  padding: 10px 18px;
+}
+
+[data-theme-style="default"] .home-item:hover,
+[data-theme-style="hydro"] .home-item:hover {
+  background: var(--bg-secondary);
+  border-left-color: transparent;
 }
 
 .home-item-title {
@@ -484,5 +573,25 @@
 
   .hitokoto-from {
     display: none;
+  }
+}
+
+/* Default & Hydro: centered hero on mobile */
+@media (max-width: 768px) {
+  [data-theme-style="default"] .home-hero,
+  [data-theme-style="hydro"] .home-hero {
+    text-align: center;
+    align-items: center;
+    padding: 20px;
+  }
+
+  [data-theme-style="default"] .home-hero-left,
+  [data-theme-style="hydro"] .home-hero-left {
+    align-items: center;
+  }
+
+  [data-theme-style="default"] .home-stats-grid,
+  [data-theme-style="hydro"] .home-stats-grid {
+    width: 100%;
   }
 }

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -1,30 +1,30 @@
 .home-page {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
-/* Hero Section */
+/* ── Hero ── */
 .home-hero {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
-  padding: 32px;
-  background: var(--accent-light);
-  border: 1px solid var(--accent);
+  padding: 20px 24px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: var(--radius-lg);
 }
 
 .home-hero-left {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .home-title {
-  font-size: 28px;
-  font-weight: 800;
+  font-size: 22px;
+  font-weight: 700;
   color: var(--text-primary);
   margin: 0;
 }
@@ -33,20 +33,20 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 14px;
+  font-size: 13px;
   color: var(--text-secondary);
 }
 
 .home-welcome {
-  font-size: 15px;
-  color: var(--text-primary);
-  font-weight: 500;
+  font-size: 13px;
+  color: var(--text-secondary);
 }
 
 .home-stats-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 10px;
+  gap: 8px;
+  min-width: 320px;
 }
 
 .home-stat-card {
@@ -54,19 +54,19 @@
   align-items: center;
   gap: 8px;
   padding: 10px 14px;
-  background: var(--bg-card);
+  background: var(--bg-tertiary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   text-decoration: none;
   color: var(--text-primary);
   font-size: 13px;
   font-weight: 500;
-  transition: all var(--transition, 0.2s);
+  transition: all var(--transition, 0.15s);
 }
 
 .home-stat-card:hover {
   border-color: var(--accent);
-  background: var(--bg-secondary);
+  color: var(--accent);
 }
 
 .home-stat-card svg:first-child {
@@ -81,17 +81,17 @@
   color: var(--text-muted);
 }
 
-/* Announcement */
+/* ── Announcement ── */
 .home-announcement {
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   background: var(--accent-light);
-  border: 1px solid var(--accent);
+  border-left: 3px solid var(--accent);
   border-radius: var(--radius);
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
   line-height: 1.6;
 }
 
@@ -116,33 +116,35 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   border: none;
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
-  border-radius: 4px;
-  transition: all var(--transition, 0.2s);
+  border-radius: var(--radius);
+  transition: all var(--transition, 0.15s);
 }
 
 .home-announcement .announcement-close:hover {
-  background: var(--bg-tertiary, rgba(0,0,0,0.05));
+  background: var(--bg-tertiary);
   color: var(--text-primary);
 }
 
-/* Hitokoto */
+/* ── Hitokoto (horizontal bar like Luogu) ── */
 .home-hitokoto {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 16px 20px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   cursor: pointer;
-  transition: all var(--transition, 0.2s);
-  position: relative;
+  transition: all var(--transition, 0.15s);
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
 }
 
 .home-hitokoto:hover {
@@ -150,45 +152,48 @@
 }
 
 .hitokoto-icon {
-  color: var(--text-muted);
-  opacity: 0.5;
+  color: var(--accent);
+  flex-shrink: 0;
+  opacity: 0.7;
 }
 
 .hitokoto-text {
-  font-size: 15px;
-  line-height: 1.7;
+  flex: 1;
+  font-size: 13px;
+  line-height: 1.6;
   color: var(--text-primary);
   font-style: italic;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hitokoto-from {
+  flex-shrink: 0;
   font-size: 12px;
   color: var(--text-muted);
-  text-align: right;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hitokoto-error .hitokoto-text {
   font-style: normal;
   color: var(--text-secondary);
   font-size: 13px;
-}
-
-/* Content Grid */
-.home-content-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
+  white-space: normal;
 }
 
 /* ── Recommendation Section ── */
 .home-recommend-section {
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg, 12px);
-  padding: 18px;
+  border-radius: var(--radius-lg);
+  padding: 14px 18px;
   display: flex;
   flex-direction: column;
-  gap: 14px;
+  gap: 12px;
 }
 
 .home-recommend-header {
@@ -197,6 +202,8 @@
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
 }
 
 .recommend-title-block {
@@ -206,13 +213,27 @@
 }
 
 .recommend-icon {
-  color: var(--accent, #f59e0b);
+  color: var(--accent);
 }
 
 .home-recommend-header h2 {
   margin: 0;
-  font-size: 16px;
-  font-weight: 700;
+  font-size: 15px;
+  font-weight: 600;
+  position: relative;
+  padding-left: 10px;
+}
+
+.home-recommend-header h2::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 14px;
+  background: var(--accent);
+  border-radius: 2px;
 }
 
 .recommend-subtitle {
@@ -225,25 +246,24 @@
 .recommend-cards {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 12px;
+  gap: 10px;
 }
 
 .recommend-card {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px 14px;
-  background: var(--bg-secondary, var(--bg-tertiary));
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--bg-tertiary);
   border: 1px solid var(--border);
-  border-radius: var(--radius, 8px);
+  border-radius: var(--radius);
   text-decoration: none;
   color: var(--text-primary);
-  transition: all var(--transition, 0.2s);
+  transition: all var(--transition, 0.15s);
 }
 
 .recommend-card:hover {
   border-color: var(--accent);
-  box-shadow: var(--shadow);
 }
 
 .recommend-card-header {
@@ -262,7 +282,7 @@
   margin-left: auto;
   padding: 1px 6px;
   background: var(--accent);
-  color: white;
+  color: #fff;
   border-radius: var(--radius);
   font-size: 11px;
   font-weight: 700;
@@ -281,7 +301,7 @@
 
 .recommend-card-reason {
   font-size: 11px;
-  color: var(--text-muted, var(--text-secondary));
+  color: var(--text-muted);
   font-style: italic;
 }
 
@@ -292,11 +312,11 @@
 }
 
 .recommend-tag {
-  font-size: 10px;
+  font-size: 11px;
   color: var(--text-secondary);
-  background: var(--bg-tertiary, rgba(0,0,0,0.05));
+  background: var(--bg-secondary);
   padding: 1px 6px;
-  border-radius: 10px;
+  border-radius: var(--radius);
 }
 
 @media (max-width: 600px) {
@@ -305,10 +325,17 @@
   }
 }
 
+/* ── Content Cards ── */
+.home-content-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
 .home-card {
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg, 12px);
+  border-radius: var(--radius-lg);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -318,18 +345,33 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 18px;
+  padding: 10px 16px;
   border-bottom: 1px solid var(--border);
+  background: var(--bg-tertiary);
 }
 
 .home-card-header h2 {
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 15px;
+  font-size: 14px;
   font-weight: 600;
   margin: 0;
   color: var(--text-primary);
+  position: relative;
+  padding-left: 10px;
+}
+
+.home-card-header h2::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 14px;
+  background: var(--accent);
+  border-radius: 2px;
 }
 
 .home-card-header h2 svg {
@@ -366,20 +408,22 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 18px;
+  padding: 8px 16px;
   text-decoration: none;
   color: var(--text-primary);
-  transition: background var(--transition, 0.2s);
+  transition: background var(--transition, 0.15s);
   gap: 12px;
+  border-left: 3px solid transparent;
 }
 
 .home-item:hover {
-  background: var(--bg-secondary);
+  background: var(--bg-tertiary);
+  border-left-color: var(--accent);
 }
 
 .home-item-title {
   flex: 1;
-  font-size: 14px;
+  font-size: 13px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -402,7 +446,7 @@
   flex-shrink: 0;
   font-size: 11px;
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius);
   font-weight: 500;
 }
 
@@ -421,23 +465,24 @@
   color: var(--text-muted);
 }
 
-/* Responsive */
+/* ── Responsive ── */
 @media (max-width: 768px) {
   .home-hero {
     flex-direction: column;
-    padding: 20px;
-    text-align: center;
+    align-items: flex-start;
+    padding: 16px;
   }
 
-  .home-hero-left {
-    align-items: center;
+  .home-stats-grid {
+    width: 100%;
+    min-width: 0;
   }
 
   .home-content-grid {
     grid-template-columns: 1fr;
   }
 
-  .home-stats-grid {
-    width: 100%;
+  .hitokoto-from {
+    display: none;
   }
 }

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -11,9 +11,9 @@
   justify-content: space-between;
   gap: 24px;
   padding: 32px;
-  background: linear-gradient(135deg, var(--color-primary-alpha, rgba(59,130,246,0.1)), var(--color-info-alpha, rgba(14,165,233,0.06)));
-  border: 1px solid var(--color-primary-alpha, rgba(59,130,246,0.15));
-  border-radius: var(--radius-lg, 12px);
+  background: var(--accent-light);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-lg);
 }
 
 .home-hero-left {
@@ -25,10 +25,7 @@
 .home-title {
   font-size: 28px;
   font-weight: 800;
-  background: linear-gradient(135deg, var(--color-primary, #3b82f6), var(--color-info, #0ea5e9));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
   margin: 0;
 }
 
@@ -68,12 +65,12 @@
 }
 
 .home-stat-card:hover {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--accent);
   background: var(--bg-secondary);
 }
 
 .home-stat-card svg:first-child {
-  color: var(--color-primary, #3b82f6);
+  color: var(--accent);
 }
 
 .stat-label {
@@ -90,8 +87,8 @@
   align-items: flex-start;
   gap: 10px;
   padding: 12px 16px;
-  background: linear-gradient(135deg, var(--color-primary-alpha, rgba(59,130,246,0.08)), var(--color-info-alpha, rgba(14,165,233,0.08)));
-  border: 1px solid var(--color-primary-alpha, rgba(59,130,246,0.2));
+  background: var(--accent-light);
+  border: 1px solid var(--accent);
   border-radius: var(--radius);
   color: var(--text-primary);
   font-size: 14px;
@@ -100,7 +97,7 @@
 
 .home-announcement .announcement-icon {
   flex-shrink: 0;
-  color: var(--color-primary, #3b82f6);
+  color: var(--accent);
   margin-top: 2px;
 }
 
@@ -110,7 +107,7 @@
 }
 
 .home-announcement .announcement-content a {
-  color: var(--color-primary, #3b82f6);
+  color: var(--accent);
   text-decoration: underline;
 }
 
@@ -149,7 +146,7 @@
 }
 
 .home-hitokoto:hover {
-  border-color: var(--color-primary, #3b82f6);
+  border-color: var(--accent);
 }
 
 .hitokoto-icon {
@@ -245,9 +242,8 @@
 }
 
 .recommend-card:hover {
-  border-color: var(--accent, #3b82f6);
-  transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  border-color: var(--accent);
+  box-shadow: var(--shadow);
 }
 
 .recommend-card-header {
@@ -265,12 +261,12 @@
 .recommend-card-rating {
   margin-left: auto;
   padding: 1px 6px;
-  background: var(--accent, #3b82f6);
+  background: var(--accent);
   color: white;
-  border-radius: 4px;
+  border-radius: var(--radius);
   font-size: 11px;
   font-weight: 700;
-  font-family: 'SF Mono', monospace;
+  font-family: var(--font-mono);
 }
 
 .recommend-card-title {
@@ -337,7 +333,7 @@
 }
 
 .home-card-header h2 svg {
-  color: var(--color-primary, #3b82f6);
+  color: var(--accent);
 }
 
 .home-card-more {
@@ -347,11 +343,11 @@
   font-size: 12px;
   color: var(--text-muted);
   text-decoration: none;
-  transition: color var(--transition, 0.2s);
+  transition: color var(--transition-fast);
 }
 
 .home-card-more:hover {
-  color: var(--color-primary, #3b82f6);
+  color: var(--accent);
 }
 
 .home-card-body {
@@ -411,18 +407,18 @@
 }
 
 .home-item-status.status-running {
-  background: rgba(34,197,94,0.1);
-  color: #22c55e;
+  background: var(--success-bg);
+  color: var(--success);
 }
 
 .home-item-status.status-upcoming {
-  background: rgba(59,130,246,0.1);
-  color: #3b82f6;
+  background: var(--accent-light);
+  color: var(--accent);
 }
 
 .home-item-status.status-ended {
-  background: rgba(107,114,128,0.1);
-  color: #6b7280;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
 }
 
 /* Responsive */

--- a/frontend/src/pages/Login.css
+++ b/frontend/src/pages/Login.css
@@ -16,7 +16,7 @@
   justify-content: center;
   width: 80px;
   height: 80px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   background: var(--accent-light);
   color: var(--accent);
   margin-bottom: 24px;
@@ -142,7 +142,7 @@
 .auth-form input:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(108, 140, 255, 0.15);
+  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.15);
 }
 
 .form-error {

--- a/frontend/src/pages/Messages.css
+++ b/frontend/src/pages/Messages.css
@@ -1,4 +1,4 @@
-﻿.messages-page {
+.messages-page {
   height: calc(100vh - 60px);
   padding: 16px;
 }
@@ -10,8 +10,8 @@
   display: grid;
   grid-template-columns: 320px 1fr;
   gap: 12px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   overflow: hidden;
 }
@@ -29,7 +29,7 @@
   align-items: center;
   gap: 10px;
   padding: 14px 16px;
-  border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-bottom: 1px solid var(--border);
   font-weight: 600;
 }
 
@@ -99,7 +99,7 @@
 
 .conv-preview {
   font-size: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -139,8 +139,8 @@
 .message-bubble {
   max-width: 70%;
   padding: 10px 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.06));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
 }
 
@@ -156,7 +156,7 @@
 
 .message-time {
   font-size: 11px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   margin-top: 4px;
   text-align: right;
 }
@@ -165,14 +165,14 @@
   display: flex;
   gap: 8px;
   padding: 12px 16px;
-  border-top: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-top: 1px solid var(--border);
 }
 
 .message-input-form input {
   flex: 1;
   padding: 10px 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.06));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   color: inherit;
   outline: none;
@@ -189,7 +189,7 @@
   align-items: center;
   justify-content: center;
   gap: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   font-size: 13px;
 }
 
@@ -223,7 +223,7 @@
   padding: 0;
   border: none;
   background: transparent;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   cursor: pointer;
   border-radius: 6px;
   transition: all 0.15s;
@@ -239,7 +239,7 @@
   align-self: center;
   padding: 8px 18px;
   background: var(--bg-tertiary, rgba(255,255,255,0.04));
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   border: 1px solid var(--border);
   border-radius: 16px;
   font-size: 12px;
@@ -278,7 +278,7 @@
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 12px 40px rgba(0,0,0,0.4);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 }
 
 .msg-modal-header {
@@ -316,7 +316,7 @@
 }
 
 .msg-search-icon {
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   flex-shrink: 0;
 }
 
@@ -341,7 +341,7 @@
 .msg-search-empty {
   padding: 24px 8px;
   text-align: center;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   font-size: 13px;
 }
 
@@ -397,7 +397,6 @@
   border-radius: 8px;
   background: var(--accent);
   color: #fff;
-  text-transform: uppercase;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/pages/Messages.css
+++ b/frontend/src/pages/Messages.css
@@ -1,4 +1,4 @@
-.messages-page {
+﻿.messages-page {
   height: calc(100vh - 60px);
   padding: 16px;
 }
@@ -66,7 +66,7 @@
 
 .conversation-item.active {
   background: rgba(99, 102, 241, 0.12);
-  border-left: 3px solid var(--primary-color, #6366f1);
+  border-left: 3px solid var(--accent);
 }
 
 .conv-avatar {
@@ -78,7 +78,7 @@
 }
 
 .conv-avatar.placeholder {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  background: var(--accent);
   color: #fff;
   display: flex;
   align-items: center;
@@ -179,7 +179,7 @@
 }
 
 .message-input-form input:focus {
-  border-color: var(--primary-color, #6366f1);
+  border-color: var(--accent);
 }
 
 .panel-empty {
@@ -197,7 +197,7 @@
 .new-conv-btn {
   margin-left: auto;
   background: var(--bg-tertiary);
-  color: var(--accent, #6366f1);
+  color: var(--accent);
   border: 1px solid var(--border);
   border-radius: 6px;
   cursor: pointer;
@@ -209,9 +209,9 @@
 }
 
 .new-conv-btn:hover {
-  background: var(--accent, #6366f1);
+  background: var(--accent);
   color: #fff;
-  border-color: var(--accent, #6366f1);
+  border-color: var(--accent);
 }
 
 .btn-icon-sm {
@@ -248,8 +248,8 @@
 }
 
 .load-more-btn:hover:not(:disabled) {
-  border-color: var(--accent, #6366f1);
-  color: var(--accent, #6366f1);
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 .load-more-btn:disabled {
@@ -368,7 +368,7 @@
 }
 
 .msg-user-avatar.placeholder {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  background: var(--accent);
   color: #fff;
   display: flex;
   align-items: center;
@@ -395,7 +395,7 @@
   font-weight: 600;
   padding: 1px 6px;
   border-radius: 8px;
-  background: var(--accent, #6366f1);
+  background: var(--accent);
   color: #fff;
   text-transform: uppercase;
 }

--- a/frontend/src/pages/Notifications.css
+++ b/frontend/src/pages/Notifications.css
@@ -1,4 +1,4 @@
-.notifications-page {
+﻿.notifications-page {
   max-width: 800px;
   margin: 0 auto;
   padding: 24px;
@@ -42,9 +42,9 @@
 }
 
 .type-tab.active {
-  background: var(--primary-color, #6366f1);
+  background: var(--accent);
   color: #fff;
-  border-color: var(--primary-color, #6366f1);
+  border-color: var(--accent);
 }
 
 .notifications-list {
@@ -67,7 +67,7 @@
 
 .notification-item:hover {
   background: rgba(99, 102, 241, 0.06);
-  border-color: var(--primary-color, #6366f1);
+  border-color: var(--accent);
 }
 
 .notification-item.unread {
@@ -106,7 +106,7 @@
 }
 
 .read-indicator {
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
   flex-shrink: 0;
   margin-top: 4px;
 }

--- a/frontend/src/pages/Notifications.css
+++ b/frontend/src/pages/Notifications.css
@@ -1,4 +1,4 @@
-﻿.notifications-page {
+.notifications-page {
   max-width: 800px;
   margin: 0 auto;
   padding: 24px;
@@ -28,10 +28,10 @@
 
 .type-tab {
   padding: 6px 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 999px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 13px;
   transition: all 0.15s;
@@ -58,8 +58,8 @@
   align-items: flex-start;
   gap: 12px;
   padding: 14px 16px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 10px;
   cursor: pointer;
   transition: background 0.15s, border-color 0.15s;
@@ -95,13 +95,13 @@
 
 .notification-desc {
   font-size: 13px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   margin-top: 4px;
 }
 
 .notification-time {
   font-size: 12px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
   margin-top: 6px;
 }
 
@@ -114,7 +114,7 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .empty-state p {

--- a/frontend/src/pages/ProblemDetail.css
+++ b/frontend/src/pages/ProblemDetail.css
@@ -146,8 +146,8 @@
 .difficulty-badge[data-difficulty="普及"]     { color: var(--diff-mid); border-color: var(--diff-mid); background: color-mix(in srgb, var(--diff-mid) 12%, transparent); }
 .difficulty-badge[data-difficulty="提高"]     { color: var(--diff-hard); border-color: var(--diff-hard); background: color-mix(in srgb, var(--diff-hard) 12%, transparent); }
 .difficulty-badge[data-difficulty="提高+"]    { color: var(--diff-hard-plus); border-color: var(--diff-hard-plus); background: color-mix(in srgb, var(--diff-hard-plus) 12%, transparent); }
-.difficulty-badge[data-difficulty="省�?"]    { color: var(--diff-province); border-color: var(--diff-province); background: color-mix(in srgb, var(--diff-province) 12%, transparent); }
-.difficulty-badge[data-difficulty="省�?]     { color: var(--diff-province-plus); border-color: var(--diff-province-plus); background: color-mix(in srgb, var(--diff-province-plus) 12%, transparent); }
+.difficulty-badge[data-difficulty="省选-"]    { color: var(--diff-province); border-color: var(--diff-province); background: color-mix(in srgb, var(--diff-province) 12%, transparent); }
+.difficulty-badge[data-difficulty="省选"]     { color: var(--diff-province-plus); border-color: var(--diff-province-plus); background: color-mix(in srgb, var(--diff-province-plus) 12%, transparent); }
 .difficulty-badge[data-difficulty="NOI"]      { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }
 .difficulty-badge[data-difficulty="NOI+"]     { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }
 .difficulty-badge[data-difficulty="CTSC"]     { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }

--- a/frontend/src/pages/ProblemDetail.css
+++ b/frontend/src/pages/ProblemDetail.css
@@ -132,10 +132,25 @@
 .difficulty-badge {
   font-size: 13px;
   font-weight: 600;
-  padding: 6px 16px;
-  border-radius: 20px;
+  padding: 4px 12px;
+  border-radius: var(--radius);
   border: 1px solid;
+  display: inline-flex;
+  align-items: center;
 }
+
+/* Luogu-style difficulty badge backgrounds */
+.difficulty-badge[data-difficulty="暂无难度"] { color: var(--diff-none); border-color: var(--diff-none); background: color-mix(in srgb, var(--diff-none) 12%, transparent); }
+.difficulty-badge[data-difficulty="入门"]     { color: var(--diff-easy); border-color: var(--diff-easy); background: color-mix(in srgb, var(--diff-easy) 12%, transparent); }
+.difficulty-badge[data-difficulty="普及-"]    { color: var(--diff-easy-mid); border-color: var(--diff-easy-mid); background: color-mix(in srgb, var(--diff-easy-mid) 12%, transparent); }
+.difficulty-badge[data-difficulty="普及"]     { color: var(--diff-mid); border-color: var(--diff-mid); background: color-mix(in srgb, var(--diff-mid) 12%, transparent); }
+.difficulty-badge[data-difficulty="提高"]     { color: var(--diff-hard); border-color: var(--diff-hard); background: color-mix(in srgb, var(--diff-hard) 12%, transparent); }
+.difficulty-badge[data-difficulty="提高+"]    { color: var(--diff-hard-plus); border-color: var(--diff-hard-plus); background: color-mix(in srgb, var(--diff-hard-plus) 12%, transparent); }
+.difficulty-badge[data-difficulty="省�?"]    { color: var(--diff-province); border-color: var(--diff-province); background: color-mix(in srgb, var(--diff-province) 12%, transparent); }
+.difficulty-badge[data-difficulty="省�?]     { color: var(--diff-province-plus); border-color: var(--diff-province-plus); background: color-mix(in srgb, var(--diff-province-plus) 12%, transparent); }
+.difficulty-badge[data-difficulty="NOI"]      { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }
+.difficulty-badge[data-difficulty="NOI+"]     { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }
+.difficulty-badge[data-difficulty="CTSC"]     { color: var(--diff-noi); border-color: var(--diff-noi); background: color-mix(in srgb, var(--diff-noi) 12%, transparent); }
 
 .favorite-btn {
   display: flex;
@@ -185,7 +200,7 @@
 .action-btn-outline:hover {
   border-color: var(--accent);
   color: var(--accent);
-  background: var(--accent-light, rgba(108, 140, 255, 0.08));
+  background: var(--accent-light);
 }
 
 .problem-meta {
@@ -200,11 +215,11 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  font-size: 13px;
+  font-size: 12px;
   color: var(--text-secondary);
   background: var(--bg-tertiary);
-  padding: 4px 10px;
-  border-radius: 20px;
+  padding: 3px 10px;
+  border-radius: var(--radius);
 }
 
 .meta-item.pass-rate {
@@ -294,8 +309,6 @@
   color: var(--text-muted);
   background: var(--bg-tertiary);
   border-bottom: 1px solid var(--border);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
 }
 
 .sample-box pre {
@@ -573,7 +586,7 @@
 
 .filter-btn.active {
   color: var(--accent);
-  background: var(--accent-light, rgba(108, 140, 255, 0.08));
+  background: var(--accent-light);
   border-color: var(--accent);
 }
 
@@ -687,7 +700,7 @@
 
 .inline-card:hover {
   border-color: var(--accent);
-  background: var(--accent-light, rgba(108, 140, 255, 0.04));
+  background: var(--accent-light);
 }
 
 .inline-card.pinned {
@@ -771,8 +784,8 @@
   font-size: 11px;
   font-weight: 600;
   color: var(--accent);
-  background: var(--accent-light, rgba(108, 140, 255, 0.08));
-  border-radius: 4px;
+  background: var(--accent-light);
+  border-radius: var(--radius);
   flex-shrink: 0;
 }
 
@@ -783,7 +796,7 @@
   padding: 2px 8px;
   font-size: 11px;
   font-weight: 600;
-  border-radius: 4px;
+  border-radius: var(--radius);
   flex-shrink: 0;
 }
 

--- a/frontend/src/pages/ProblemDetail.tsx
+++ b/frontend/src/pages/ProblemDetail.tsx
@@ -13,7 +13,7 @@ import { useThemeStore } from '../store/theme';
 import { useToastStore } from '../store/toast';
 import StatusBadge from '../components/StatusBadge';
 import { Send, Clock, MemoryStick, ChevronLeft, ChevronRight, Tag, Heart, CheckCircle, XCircle, AlertCircle, Users, BookOpen, MessageSquare, ThumbsUp, Eye, Plus, X, Sparkles, Flag } from 'lucide-react';
-import { LANGUAGES, LANGUAGE_TEMPLATES, DIFFICULTY_COLORS } from '../constants';
+import { LANGUAGES, LANGUAGE_TEMPLATES } from '../constants';
 import RatingBadge from '../components/RatingBadge';
 import { renderMarkdown } from '../utils/markdown';
 import { t } from '../i18n';
@@ -629,7 +629,7 @@ export default function ProblemDetail() {
             ) : (
               <div
                 className="difficulty-badge"
-                style={{ background: `${DIFFICULTY_COLORS[problem.difficulty]}20`, color: DIFFICULTY_COLORS[problem.difficulty], borderColor: DIFFICULTY_COLORS[problem.difficulty] }}
+                data-difficulty={problem.difficulty || ''}
               >
                 {problem.difficulty}
               </div>

--- a/frontend/src/pages/ProblemList.css
+++ b/frontend/src/pages/ProblemList.css
@@ -1,7 +1,7 @@
 .problem-list-page {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
 .page-header {
@@ -12,59 +12,25 @@
 }
 
 .page-header h1 {
-  font-size: 24px;
+  font-size: 22px;
   font-weight: 700;
+  position: relative;
+  padding-left: 12px;
 }
 
-.announcement-banner {
-  display: flex;
-  align-items: flex-start;
-  gap: 10px;
-  padding: 12px 16px;
-  background: var(--accent-light);
-  border: 1px solid var(--accent);
-  border-radius: var(--radius);
-  color: var(--text-primary);
-  font-size: 14px;
-  line-height: 1.6;
+.page-header h1::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 18px;
+  background: var(--accent);
+  border-radius: 2px;
 }
 
-.announcement-icon {
-  flex-shrink: 0;
-  color: var(--accent);
-  margin-top: 2px;
-}
-
-.announcement-content {
-  flex: 1;
-  min-width: 0;
-}
-
-.announcement-content a {
-  color: var(--accent);
-  text-decoration: underline;
-}
-
-.announcement-close {
-  flex-shrink: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border: none;
-  background: transparent;
-  color: var(--text-muted);
-  cursor: pointer;
-  border-radius: 4px;
-  transition: all var(--transition);
-}
-
-.announcement-close:hover {
-  background: var(--bg-tertiary, rgba(0,0,0,0.05));
-  color: var(--text-primary);
-}
-
+/* ── Search ── */
 .search-bar {
   display: flex;
   align-items: center;
@@ -72,9 +38,10 @@
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 8px 14px;
+  padding: 6px 12px;
   width: 300px;
   transition: border-color var(--transition);
+  color: var(--text-muted);
 }
 
 .search-bar:focus-within {
@@ -86,7 +53,7 @@
   border: none;
   outline: none;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
   width: 100%;
 }
 
@@ -94,13 +61,19 @@
   color: var(--text-muted);
 }
 
+/* ── Filters ── */
 .filters {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 12px 16px;
 }
 
-.difficulty-filter {
+.difficulty-filter,
+.tag-filter {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -110,14 +83,33 @@
 
 .filter-label {
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 40px;
+}
+
+.filter-select {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 5px 10px;
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+  transition: border-color var(--transition);
+}
+
+.filter-select:focus,
+.filter-select:hover {
+  border-color: var(--accent);
 }
 
 .difficulty-chip {
   display: inline-flex;
   align-items: center;
-  padding: 4px 12px;
-  border-radius: 20px;
+  padding: 3px 10px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
   background: var(--bg-tertiary);
@@ -134,19 +126,11 @@
   border: 1px solid;
 }
 
-.tag-filter {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  color: var(--text-secondary);
-  flex-wrap: wrap;
-}
-
 .tag-chip {
   display: inline-flex;
   align-items: center;
-  padding: 4px 10px;
-  border-radius: 20px;
+  padding: 3px 10px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 500;
   background: var(--bg-tertiary);
@@ -169,19 +153,19 @@
 }
 
 .tag-chip.small {
-  padding: 2px 8px;
+  padding: 1px 6px;
   font-size: 11px;
 }
 
 .clear-filters-btn {
   align-self: flex-start;
-  padding: 6px 16px;
-  font-size: 13px;
+  padding: 5px 12px;
+  font-size: 12px;
   font-weight: 500;
   background: transparent;
   color: var(--accent);
   border: 1px solid var(--accent);
-  border-radius: 20px;
+  border-radius: var(--radius);
   cursor: pointer;
   transition: all var(--transition);
 }
@@ -190,17 +174,19 @@
   background: var(--accent-light);
 }
 
+/* ── Problem Table ── */
 .problem-table {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
+  overflow: hidden;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
 
 .problem-table-header {
   display: grid;
-  grid-template-columns: 36px 50px 1fr 80px 160px 70px 60px 140px;
+  grid-template-columns: 36px 50px 1fr 80px 160px 70px 90px 140px;
   gap: 6px;
   align-items: center;
   padding: 10px 14px;
@@ -208,25 +194,49 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border);
+  min-width: 800px;
 }
 
 .problem-row {
   display: grid;
-  grid-template-columns: 36px 50px 1fr 80px 160px 70px 60px 140px;
+  grid-template-columns: 36px 50px 1fr 80px 160px 70px 90px 140px;
   gap: 6px;
   align-items: center;
-  padding: 12px 14px;
-  border-top: 1px solid var(--border);
-  transition: all var(--transition);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  transition: background var(--transition);
   text-decoration: none;
   color: var(--text-primary);
+  border-left: 3px solid transparent;
+  min-width: 800px;
+  position: relative;
+}
+
+.problem-row:last-child {
+  border-bottom: none;
 }
 
 .problem-row:hover {
   background: var(--bg-tertiary);
 }
+
+/* Luogu-style left color bar by difficulty */
+.problem-row[data-difficulty="暂无难度"] { border-left-color: var(--diff-none); }
+.problem-row[data-difficulty="入门"]     { border-left-color: var(--diff-easy); }
+.problem-row[data-difficulty="普及-"]    { border-left-color: var(--diff-easy-mid); }
+.problem-row[data-difficulty="普及"]     { border-left-color: var(--diff-mid); }
+.problem-row[data-difficulty="提高"]     { border-left-color: var(--diff-hard); }
+.problem-row[data-difficulty="提高+"]    { border-left-color: var(--diff-hard-plus); }
+.problem-row[data-difficulty="省选-"]    { border-left-color: var(--diff-province); }
+.problem-row[data-difficulty="省选"]     { border-left-color: var(--diff-province-plus); }
+.problem-row[data-difficulty="NOI"]      { border-left-color: var(--diff-noi); }
+.problem-row[data-difficulty="NOI+"]     { border-left-color: var(--diff-noi); }
+.problem-row[data-difficulty="CTSC"]     { border-left-color: var(--diff-noi); }
+/* Legacy aliases */
+.problem-row[data-difficulty="Easy"]     { border-left-color: var(--diff-mid); }
+.problem-row[data-difficulty="Medium"]   { border-left-color: var(--diff-hard); }
+.problem-row[data-difficulty="Hard"]     { border-left-color: var(--diff-easy); }
 
 .problem-row.accepted {
   background: var(--success-bg);
@@ -251,8 +261,8 @@
 }
 
 .status-icon {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
 }
 
 .status-icon.accepted {
@@ -265,26 +275,30 @@
 
 .col-id {
   color: var(--text-muted);
-  font-size: 14px;
+  font-size: 13px;
 }
 
 .col-title {
   font-weight: 500;
-  font-size: 15px;
+  font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
 }
 
+.col-title:hover {
+  color: var(--accent);
+}
+
 .col-difficulty {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
 }
 
 .col-tags {
   display: flex;
-  gap: 6px;
+  gap: 4px;
   flex-wrap: wrap;
   overflow: hidden;
   min-width: 0;
@@ -297,37 +311,65 @@
 }
 
 .col-rate {
-  text-align: center;
-  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
   font-weight: 600;
 }
 
-.col-rate.high {
-  color: var(--success);
+.pass-rate-bar {
+  flex: 1;
+  height: 6px;
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+  overflow: hidden;
+  min-width: 30px;
 }
 
-.col-rate.medium {
-  color: var(--warning);
+.pass-rate-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s;
 }
 
-.col-rate.low {
-  color: var(--error);
+.pass-rate-fill.high {
+  background: var(--success);
 }
+
+.pass-rate-fill.medium {
+  background: var(--warning);
+}
+
+.pass-rate-fill.low {
+  background: var(--error);
+}
+
+.pass-rate-text {
+  flex-shrink: 0;
+  min-width: 32px;
+  text-align: right;
+}
+
+.pass-rate-text.high   { color: var(--success); }
+.pass-rate-text.medium { color: var(--warning); }
+.pass-rate-text.low    { color: var(--error); }
 
 .col-limit {
   display: flex;
-  gap: 12px;
+  gap: 10px;
   justify-content: flex-end;
 }
 
 .limit-item {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 12px;
+  gap: 3px;
+  font-size: 11px;
   color: var(--text-muted);
 }
 
+/* ── Pagination ── */
 .pagination {
   display: flex;
   align-items: center;
@@ -337,22 +379,23 @@
 }
 
 .page-info {
-  font-size: 14px;
+  font-size: 13px;
   color: var(--text-secondary);
 }
 
+/* ── Loading / Empty ── */
 .loading-container {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 48px;
-  gap: 16px;
+  gap: 12px;
 }
 
 .loading-spinner {
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   border: 3px solid var(--border);
   border-top-color: var(--accent);
   border-radius: 50%;
@@ -369,9 +412,10 @@
   text-align: center;
   padding: 48px;
   color: var(--text-secondary);
-  font-size: 16px;
+  font-size: 14px;
 }
 
+/* ── Responsive ── */
 @media (max-width: 768px) {
   .page-header {
     flex-direction: column;
@@ -380,11 +424,6 @@
 
   .search-bar {
     width: 100%;
-  }
-
-  .filters {
-    flex-direction: column;
-    gap: 8px;
   }
 
   .problem-table-header,

--- a/frontend/src/pages/ProblemList.css
+++ b/frontend/src/pages/ProblemList.css
@@ -21,8 +21,8 @@
   align-items: flex-start;
   gap: 10px;
   padding: 12px 16px;
-  background: linear-gradient(135deg, var(--color-primary-alpha, rgba(59,130,246,0.08)), var(--color-info-alpha, rgba(14,165,233,0.08)));
-  border: 1px solid var(--color-primary-alpha, rgba(59,130,246,0.2));
+  background: var(--accent-light);
+  border: 1px solid var(--accent);
   border-radius: var(--radius);
   color: var(--text-primary);
   font-size: 14px;
@@ -31,7 +31,7 @@
 
 .announcement-icon {
   flex-shrink: 0;
-  color: var(--color-primary, #3b82f6);
+  color: var(--accent);
   margin-top: 2px;
 }
 
@@ -41,7 +41,7 @@
 }
 
 .announcement-content a {
-  color: var(--color-primary, #3b82f6);
+  color: var(--accent);
   text-decoration: underline;
 }
 

--- a/frontend/src/pages/ProblemList.css
+++ b/frontend/src/pages/ProblemList.css
@@ -4,6 +4,12 @@
   gap: 16px;
 }
 
+/* Default & Hydro: larger gap */
+[data-theme-style="default"] .problem-list-page,
+[data-theme-style="hydro"] .problem-list-page {
+  gap: 20px;
+}
+
 .page-header {
   display: flex;
   align-items: center;
@@ -28,6 +34,18 @@
   height: 18px;
   background: var(--accent);
   border-radius: 2px;
+}
+
+/* Default & Hydro: no left accent bar on h1 */
+[data-theme-style="default"] .page-header h1,
+[data-theme-style="hydro"] .page-header h1 {
+  padding-left: 0;
+  font-size: 24px;
+}
+
+[data-theme-style="default"] .page-header h1::before,
+[data-theme-style="hydro"] .page-header h1::before {
+  display: none;
 }
 
 /* ── Search ── */
@@ -61,6 +79,18 @@
   color: var(--text-muted);
 }
 
+/* Default & Hydro: larger search bar */
+[data-theme-style="default"] .search-bar,
+[data-theme-style="hydro"] .search-bar {
+  padding: 8px 14px;
+  color: inherit;
+}
+
+[data-theme-style="default"] .search-bar input,
+[data-theme-style="hydro"] .search-bar input {
+  font-size: 14px;
+}
+
 /* ── Filters ── */
 .filters {
   display: flex;
@@ -70,6 +100,15 @@
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 12px 16px;
+}
+
+/* Default & Hydro: no card-style filters */
+[data-theme-style="default"] .filters,
+[data-theme-style="hydro"] .filters {
+  background: none;
+  border: none;
+  padding: 0;
+  gap: 12px;
 }
 
 .difficulty-filter,
@@ -196,6 +235,28 @@
   color: var(--text-secondary);
   border-bottom: 1px solid var(--border);
   min-width: 800px;
+}
+
+/* Default & Hydro: uppercase header with letter-spacing */
+[data-theme-style="default"] .problem-table-header,
+[data-theme-style="hydro"] .problem-table-header {
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  grid-template-columns: 36px 50px 1fr 80px 160px 70px 60px 140px;
+}
+
+/* Default & Hydro: no border-bottom on header, border-top on rows */
+[data-theme-style="default"] .problem-row,
+[data-theme-style="hydro"] .problem-row {
+  border-bottom: none;
+  border-top: 1px solid var(--border);
+  padding: 12px 14px;
+  grid-template-columns: 36px 50px 1fr 80px 160px 70px 60px 140px;
+}
+
+[data-theme-style="default"] .problem-row:last-child,
+[data-theme-style="hydro"] .problem-row:last-child {
+  border-bottom: none;
 }
 
 .problem-row {
@@ -439,6 +500,42 @@
   }
 
   .pagination {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
+/* Default & Hydro: responsive */
+@media (max-width: 768px) {
+  [data-theme-style="default"] .page-header,
+  [data-theme-style="hydro"] .page-header {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  [data-theme-style="default"] .search-bar,
+  [data-theme-style="hydro"] .search-bar {
+    width: 100%;
+  }
+
+  [data-theme-style="default"] .problem-table-header,
+  [data-theme-style="default"] .problem-row {
+    grid-template-columns: 30px 40px 1fr 80px;
+  }
+
+  [data-theme-style="default"] .col-tags,
+  [data-theme-style="default"] .col-limit,
+  [data-theme-style="default"] .col-submissions,
+  [data-theme-style="default"] .col-rate,
+  [data-theme-style="hydro"] .col-tags,
+  [data-theme-style="hydro"] .col-limit,
+  [data-theme-style="hydro"] .col-submissions,
+  [data-theme-style="hydro"] .col-rate {
+    display: none;
+  }
+
+  [data-theme-style="default"] .pagination,
+  [data-theme-style="hydro"] .pagination {
     flex-wrap: wrap;
     justify-content: center;
   }

--- a/frontend/src/pages/ProblemList.tsx
+++ b/frontend/src/pages/ProblemList.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { api } from '../api/client';
 import { useAuthStore } from '../store/auth';
 import { Search, Tag, Clock, MemoryStick, Filter, CheckCircle, AlertCircle } from 'lucide-react';
-import { DIFFICULTY_COLORS } from '../constants';
+import { DIFFICULTY_COLORS, DIFFICULTIES } from '../constants';
 import RatingBadge from '../components/RatingBadge';
 import { t } from '../i18n';
 import { useToastStore } from '../store/toast';
@@ -143,9 +143,9 @@ export default function ProblemList() {
             onChange={(e) => { setSelectedDifficulty(e.target.value); setPage(1); }}
           >
             <option value="">{t('problemList.allDifficulty')}</option>
-            <option value="Easy">{t('problemList.easy')}</option>
-            <option value="Medium">{t('problemList.medium')}</option>
-            <option value="Hard">{t('problemList.hard')}</option>
+            {DIFFICULTIES.map((d) => (
+              <option key={d} value={d}>{d}</option>
+            ))}
           </select>
         </div>
 
@@ -203,11 +203,16 @@ export default function ProblemList() {
           {problems.map((problem, index) => {
             const status = getProblemStatus(problem.id);
             const displayId = (pagination.page - 1) * pagination.pageSize + index + 1;
+            const rateLevel = problem.pass_rate != null
+              ? (problem.pass_rate >= 0.6 ? 'high' : problem.pass_rate >= 0.3 ? 'medium' : 'low')
+              : '';
+            const ratePct = problem.pass_rate != null ? Math.round(problem.pass_rate * 100) : null;
             return (
               <Link
                 key={problem.id}
                 to={`/problems/${problem.slug}`}
                 className={`problem-row ${status}`}
+                data-difficulty={problem.difficulty || ''}
               >
                 <span className="col-status">
                   {status === 'accepted' && <CheckCircle size={16} className="status-icon accepted" />}
@@ -219,7 +224,7 @@ export default function ProblemList() {
                   {problem.rating && problem.rating >= 800 ? (
                     <RatingBadge rating={problem.rating} size="sm" />
                   ) : (
-                    <span style={{ color: DIFFICULTY_COLORS[problem.difficulty] }}>
+                    <span style={{ color: DIFFICULTY_COLORS[problem.difficulty] || 'var(--text-secondary)' }}>
                       {problem.difficulty}
                     </span>
                   )}
@@ -236,7 +241,21 @@ export default function ProblemList() {
                   })()}
                 </span>
                 <span className="col-submissions">{problem.submission_count || 0}</span>
-                <span className={`col-rate ${problem.pass_rate != null ? (problem.pass_rate >= 0.6 ? 'high' : problem.pass_rate >= 0.3 ? 'medium' : 'low') : ''}`}>{problem.pass_rate != null ? `${Math.round(problem.pass_rate * 100)}%` : '-'}</span>
+                <span className="col-rate">
+                  {ratePct !== null ? (
+                    <>
+                      <span className="pass-rate-bar">
+                        <span
+                          className={`pass-rate-fill ${rateLevel}`}
+                          style={{ width: `${ratePct}%` }}
+                        />
+                      </span>
+                      <span className={`pass-rate-text ${rateLevel}`}>{ratePct}%</span>
+                    </>
+                  ) : (
+                    <span className="pass-rate-text">-</span>
+                  )}
+                </span>
                 <span className="col-limit">
                   <span className="limit-item">
                     <Clock size={12} /> {problem.time_limit}ms

--- a/frontend/src/pages/ProblemListDetail.css
+++ b/frontend/src/pages/ProblemListDetail.css
@@ -107,7 +107,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 

--- a/frontend/src/pages/ProblemLists.css
+++ b/frontend/src/pages/ProblemLists.css
@@ -36,7 +36,7 @@
   padding: 8px 14px;
   background: var(--bg-card);
   border: 1px solid var(--border);
-  border-radius: 20px;
+  border-radius: var(--radius);
   color: var(--text-muted);
   min-width: 240px;
 }

--- a/frontend/src/pages/Profile.css
+++ b/frontend/src/pages/Profile.css
@@ -81,7 +81,7 @@
   border-radius: var(--radius-lg);
   width: 90%;
   max-width: 440px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 }
 
 .modal-header {
@@ -186,7 +186,7 @@
 
 .badge {
   padding: 4px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -300,7 +300,6 @@
 
 .problem-card:hover {
   border-color: var(--accent);
-  transform: translateY(-2px);
 }
 
 .problem-card.solved {

--- a/frontend/src/pages/Rankings.css
+++ b/frontend/src/pages/Rankings.css
@@ -117,7 +117,7 @@
   border: 1px solid var(--border);
   background: var(--bg-card);
   color: var(--text-secondary);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -205,7 +205,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -353,7 +352,6 @@
 .score-label {
   font-size: 12px;
   color: var(--text-muted);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 

--- a/frontend/src/pages/SolutionDetail.css
+++ b/frontend/src/pages/SolutionDetail.css
@@ -85,7 +85,7 @@
   align-items: center;
   gap: 5px;
   padding: 4px 12px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
   background: var(--accent-light);

--- a/frontend/src/pages/Solutions.css
+++ b/frontend/src/pages/Solutions.css
@@ -203,7 +203,7 @@
   align-items: center;
   gap: 4px;
   padding: 2px 8px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 11px;
   font-weight: 600;
   background: var(--accent-light);

--- a/frontend/src/pages/SubmissionDetail.css
+++ b/frontend/src/pages/SubmissionDetail.css
@@ -41,7 +41,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-muted);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 4px;
 }
@@ -133,7 +132,6 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-muted);
-  text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
@@ -214,7 +212,6 @@
   text-align: left;
   font-weight: 600;
   font-size: 12px;
-  text-transform: uppercase;
   letter-spacing: 0.5px;
   color: var(--text-muted);
   border-bottom: 1px solid var(--border);
@@ -319,7 +316,6 @@
   border-radius: 4px;
   font-size: 11px;
   font-weight: 600;
-  text-transform: uppercase;
   letter-spacing: 0.5px;
   white-space: nowrap;
   background: var(--bg-tertiary);

--- a/frontend/src/pages/Submissions.css
+++ b/frontend/src/pages/Submissions.css
@@ -1,13 +1,14 @@
 .submissions-page {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
 .filter-bar {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .filter-select {
@@ -15,12 +16,15 @@
   color: var(--text-primary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 6px 12px;
-  font-size: 14px;
+  padding: 5px 10px;
+  font-size: 13px;
   outline: none;
+  cursor: pointer;
+  transition: border-color var(--transition);
 }
 
-.filter-select:focus {
+.filter-select:focus,
+.filter-select:hover {
   border-color: var(--accent);
 }
 
@@ -31,7 +35,8 @@
   background: var(--bg-secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 6px 12px;
+  padding: 5px 10px;
+  color: var(--text-muted);
 }
 
 .user-search-input input {
@@ -39,7 +44,7 @@
   border: none;
   outline: none;
   color: var(--text-primary);
-  font-size: 14px;
+  font-size: 13px;
   width: 140px;
 }
 
@@ -47,10 +52,12 @@
   color: var(--text-muted);
 }
 
+/* ── Submissions Table ── */
 .submissions-table {
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
+  overflow: hidden;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
 }
@@ -63,8 +70,7 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--border);
   min-width: 700px;
 }
 
@@ -72,23 +78,28 @@
   display: flex;
   align-items: center;
   padding: 10px 14px;
-  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
   transition: background var(--transition);
   text-decoration: none;
   color: var(--text-primary);
   min-width: 700px;
 }
 
+.submission-row:last-child {
+  border-bottom: none;
+}
+
 .submission-row:hover {
   background: var(--bg-tertiary);
 }
 
-.col-id { width: 60px; color: var(--text-muted); font-size: 14px; }
+.col-id { width: 60px; color: var(--text-muted); font-size: 13px; }
 .col-user { width: 100px; color: var(--text-secondary); font-size: 13px; }
-.col-problem { flex: 1; font-weight: 500; }
+.col-problem { flex: 1; font-weight: 500; font-size: 14px; }
+.col-problem:hover { color: var(--accent); }
 .col-lang { width: 100px; color: var(--text-secondary); font-size: 13px; }
 .col-status { width: 140px; }
-.col-score { width: 60px; text-align: center; }
+.col-score { width: 60px; text-align: center; font-weight: 600; }
 .col-time { width: 80px; color: var(--text-secondary); font-size: 13px; }
 .col-memory { width: 90px; color: var(--text-secondary); font-size: 13px; }
 .col-date { width: 160px; color: var(--text-muted); font-size: 12px; }
@@ -98,14 +109,15 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 16px;
-  padding: 80px 0;
+  gap: 12px;
+  padding: 60px 0;
   text-align: center;
 }
 
 .empty-page h2 {
   color: var(--text-secondary);
   font-weight: 500;
+  font-size: 16px;
 }
 
 .empty-page .empty-icon {
@@ -115,7 +127,7 @@
 
 .empty-page .empty-desc {
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: 13px;
   margin: 0;
 }
 

--- a/frontend/src/pages/Submissions.css
+++ b/frontend/src/pages/Submissions.css
@@ -4,6 +4,12 @@
   gap: 16px;
 }
 
+/* Default & Hydro: larger gap */
+[data-theme-style="default"] .submissions-page,
+[data-theme-style="hydro"] .submissions-page {
+  gap: 20px;
+}
+
 .filter-bar {
   display: flex;
   align-items: center;
@@ -26,6 +32,13 @@
 .filter-select:focus,
 .filter-select:hover {
   border-color: var(--accent);
+}
+
+/* Default & Hydro: larger filter select */
+[data-theme-style="default"] .filter-select,
+[data-theme-style="hydro"] .filter-select {
+  padding: 6px 12px;
+  font-size: 14px;
 }
 
 .user-search-input {
@@ -74,6 +87,13 @@
   min-width: 700px;
 }
 
+/* Default & Hydro: uppercase header with letter-spacing */
+[data-theme-style="default"] .submissions-table-header,
+[data-theme-style="hydro"] .submissions-table-header {
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
 .submission-row {
   display: flex;
   align-items: center;
@@ -91,6 +111,18 @@
 
 .submission-row:hover {
   background: var(--bg-tertiary);
+}
+
+/* Default & Hydro: border-top on rows instead of border-bottom */
+[data-theme-style="default"] .submission-row,
+[data-theme-style="hydro"] .submission-row {
+  border-bottom: none;
+  border-top: 1px solid var(--border);
+}
+
+[data-theme-style="default"] .submission-row:last-child,
+[data-theme-style="hydro"] .submission-row:last-child {
+  border-bottom: none;
 }
 
 .col-id { width: 60px; color: var(--text-muted); font-size: 13px; }

--- a/frontend/src/pages/Teams.css
+++ b/frontend/src/pages/Teams.css
@@ -1,4 +1,4 @@
-.teams-page {
+﻿.teams-page {
   max-width: 1100px;
   margin: 0 auto;
   padding: 24px;
@@ -68,7 +68,7 @@
 
 .team-card:hover {
   transform: translateY(-2px);
-  border-color: var(--primary-color, #6366f1);
+  border-color: var(--accent);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
 }
 
@@ -81,7 +81,7 @@
 }
 
 .team-avatar.placeholder {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  background: var(--accent);
   color: #fff;
   display: flex;
   align-items: center;
@@ -137,7 +137,7 @@
 }
 
 .back-link:hover {
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
 }
 
 .team-detail-header {
@@ -207,8 +207,8 @@
 }
 
 .team-tab.active {
-  color: var(--primary-color, #6366f1);
-  border-bottom-color: var(--primary-color, #6366f1);
+  color: var(--accent);
+  border-bottom-color: var(--accent);
 }
 
 .members-list,
@@ -243,7 +243,7 @@
 }
 
 .member-avatar.placeholder {
-  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  background: var(--accent);
   color: #fff;
   display: flex;
   align-items: center;
@@ -260,7 +260,7 @@
 }
 
 .member-name:hover {
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
 }
 
 .member-role {
@@ -326,7 +326,7 @@
 
 .create-team-form input:focus,
 .create-team-form textarea:focus {
-  border-color: var(--primary-color, #6366f1);
+  border-color: var(--accent);
 }
 
 .checkbox-label {

--- a/frontend/src/pages/Teams.css
+++ b/frontend/src/pages/Teams.css
@@ -1,4 +1,4 @@
-﻿.teams-page {
+.teams-page {
   max-width: 1100px;
   margin: 0 auto;
   padding: 24px;
@@ -33,8 +33,8 @@
   align-items: center;
   gap: 8px;
   padding: 6px 12px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   min-width: 240px;
 }
@@ -58,8 +58,8 @@
   align-items: center;
   gap: 14px;
   padding: 16px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   text-decoration: none;
   color: inherit;
@@ -67,9 +67,7 @@
 }
 
 .team-card:hover {
-  transform: translateY(-2px);
   border-color: var(--accent);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
 }
 
 .team-avatar {
@@ -108,7 +106,7 @@
 .team-desc {
   margin: 0 0 4px 0;
   font-size: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -117,7 +115,7 @@
 
 .team-meta {
   font-size: 12px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .team-detail-page {
@@ -130,7 +128,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   text-decoration: none;
   font-size: 13px;
   margin-bottom: 16px;
@@ -144,8 +142,8 @@
   display: flex;
   gap: 20px;
   padding: 24px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   margin-bottom: 24px;
 }
@@ -163,7 +161,7 @@
   display: flex;
   gap: 12px;
   font-size: 13px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   margin-top: 6px;
 }
 
@@ -190,7 +188,7 @@
   display: flex;
   gap: 6px;
   margin-bottom: 16px;
-  border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  border-bottom: 1px solid var(--border);
 }
 
 .team-tab {
@@ -201,7 +199,7 @@
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   cursor: pointer;
   font-size: 14px;
 }
@@ -223,8 +221,8 @@
   align-items: center;
   gap: 12px;
   padding: 12px 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
 }
 
@@ -232,7 +230,7 @@
   width: 24px;
   text-align: center;
   font-weight: 600;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .member-avatar {
@@ -282,12 +280,12 @@
 
 .member-role.member {
   background: rgba(255, 255, 255, 0.06);
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .member-stats {
   font-size: 12px;
-  color: var(--text-secondary, #888);
+  color: var(--text-secondary);
 }
 
 .create-team-page {
@@ -317,8 +315,8 @@
 .create-team-form input,
 .create-team-form textarea {
   padding: 10px 12px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   color: inherit;
   outline: none;
@@ -338,7 +336,7 @@
 .empty-state {
   text-align: center;
   padding: 60px 20px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .empty-state p {

--- a/frontend/src/pages/TicketDetail.css
+++ b/frontend/src/pages/TicketDetail.css
@@ -214,7 +214,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -225,7 +225,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -236,7 +236,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -247,7 +247,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }

--- a/frontend/src/pages/Tickets.css
+++ b/frontend/src/pages/Tickets.css
@@ -55,7 +55,7 @@
   border: 1px solid var(--border);
   background: var(--bg-card);
   color: var(--text-secondary);
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
@@ -136,7 +136,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }
@@ -147,7 +147,7 @@
   display: inline-flex;
   align-items: center;
   padding: 3px 10px;
-  border-radius: 20px;
+  border-radius: var(--radius);
   font-size: 12px;
   font-weight: 600;
 }

--- a/frontend/src/pages/Training.css
+++ b/frontend/src/pages/Training.css
@@ -1,4 +1,4 @@
-﻿.training-page {
+.training-page {
   max-width: 1200px;
   margin: 0 auto;
   padding: 24px;
@@ -28,8 +28,8 @@
   align-items: center;
   gap: 8px;
   padding: 8px 14px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 8px;
   min-width: 280px;
 }
@@ -51,8 +51,8 @@
 .training-card {
   display: flex;
   flex-direction: column;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
   overflow: hidden;
   text-decoration: none;
@@ -61,8 +61,6 @@
 }
 
 .training-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
   border-color: var(--accent);
 }
 
@@ -102,18 +100,18 @@
 }
 
 .official-badge {
-  background: linear-gradient(135deg, #ffc800, #ff7c00);
+  background: var(--warning);
   color: #fff;
   font-size: 11px;
   padding: 2px 8px;
-  border-radius: 999px;
+  border-radius: var(--radius);
   font-weight: 600;
 }
 
 .training-card-desc {
   margin: 0;
   font-size: 13px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -127,7 +125,7 @@
   gap: 12px;
   flex-wrap: wrap;
   font-size: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .difficulty-tag {
@@ -153,20 +151,20 @@
 
 .progress-bar {
   height: 6px;
-  background: var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--border);
   border-radius: 3px;
   overflow: hidden;
 }
 
 .progress-bar-inner {
   height: 100%;
-  background: linear-gradient(90deg, #52c41a, #3498db);
+  background: var(--accent);
   transition: width 0.4s;
 }
 
 .progress-text {
   font-size: 11px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 /* Detail page */
@@ -182,8 +180,8 @@
   gap: 12px;
   margin-bottom: 24px;
   padding: 24px;
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 12px;
 }
 
@@ -198,7 +196,7 @@
   gap: 16px;
   flex-wrap: wrap;
   font-size: 13px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .training-detail-header .progress-section {
@@ -215,8 +213,8 @@
 }
 
 .chapter-item {
-  background: var(--card-bg, rgba(255, 255, 255, 0.04));
-  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  background: var(--bg-card);
+  border: 1px solid var(--border);
   border-radius: 10px;
   overflow: hidden;
 }
@@ -282,13 +280,13 @@
 
 .chapter-problem-row .problem-meta {
   font-size: 12px;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
 }
 
 .empty-chapter {
   padding: 16px;
   text-align: center;
-  color: var(--text-secondary, #aaa);
+  color: var(--text-secondary);
   font-size: 13px;
 }
 

--- a/frontend/src/pages/Training.css
+++ b/frontend/src/pages/Training.css
@@ -1,4 +1,4 @@
-.training-page {
+﻿.training-page {
   max-width: 1200px;
   margin: 0 auto;
   padding: 24px;
@@ -20,7 +20,7 @@
 }
 
 .training-title-section .title-icon {
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
 }
 
 .training-header .search-bar {
@@ -63,7 +63,7 @@
 .training-card:hover {
   transform: translateY(-3px);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
-  border-color: var(--primary-color, #6366f1);
+  border-color: var(--accent);
 }
 
 .training-card-cover {
@@ -77,7 +77,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--primary-color, #6366f1);
+  color: var(--accent);
 }
 
 .training-card-body {

--- a/frontend/src/site-config.d.ts
+++ b/frontend/src/site-config.d.ts
@@ -5,6 +5,7 @@ export interface SiteConfig {
     description: string;
     icon: string;
     favicon: string;
+    theme: 'default' | 'luogu' | 'hydro';
   };
   footer: {
     enabled: boolean;

--- a/frontend/src/store/theme.ts
+++ b/frontend/src/store/theme.ts
@@ -6,7 +6,7 @@ interface ThemeState {
   setTheme: (theme: 'dark' | 'light') => void;
 }
 
-const savedTheme = (localStorage.getItem('theme') as 'dark' | 'light') || 'light';
+const savedTheme = (localStorage.getItem('theme') as 'dark' | 'light') || 'dark';
 
 export const useThemeStore = create<ThemeState>((set) => ({
   theme: savedTheme,

--- a/frontend/src/store/theme.ts
+++ b/frontend/src/store/theme.ts
@@ -6,7 +6,7 @@ interface ThemeState {
   setTheme: (theme: 'dark' | 'light') => void;
 }
 
-const savedTheme = (localStorage.getItem('theme') as 'dark' | 'light') || 'dark';
+const savedTheme = (localStorage.getItem('theme') as 'dark' | 'light') || 'light';
 
 export const useThemeStore = create<ThemeState>((set) => ({
   theme: savedTheme,

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -2,30 +2,18 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 11px 22px;
-  border: none;
+  gap: 4px;
+  padding: 6px 14px;
+  border: 1px solid transparent;
   border-radius: var(--radius);
   font-size: 14px;
-  font-weight: 600;
-  transition: all var(--transition);
+  font-weight: 400;
+  font-family: inherit;
+  transition: all var(--transition-fast);
   text-decoration: none;
   cursor: pointer;
   position: relative;
-  overflow: hidden;
-}
-
-.btn::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, transparent 50%);
-  opacity: 0;
-  transition: opacity var(--transition);
-}
-
-.btn:hover::before {
-  opacity: 1;
+  white-space: nowrap;
 }
 
 .btn:disabled {
@@ -34,81 +22,96 @@
 }
 
 .btn-primary {
-  background: linear-gradient(135deg, var(--accent), #8b5cf6);
-  color: white;
-  box-shadow: var(--shadow-accent);
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
 
 .btn-primary:hover:not(:disabled) {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-lg), var(--shadow-accent);
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  color: #fff;
+  text-decoration: none;
 }
 
 .btn-secondary {
-  background: var(--bg-tertiary);
+  background: var(--bg-secondary);
   color: var(--text-primary);
-  border: 1px solid var(--border);
+  border-color: var(--border);
 }
 
 .btn-secondary:hover:not(:disabled) {
-  background: var(--border);
+  background: var(--bg-tertiary);
   border-color: var(--border-hover);
+  color: var(--text-primary);
+  text-decoration: none;
 }
 
 .btn-outline {
   background: transparent;
   color: var(--accent);
-  border: 1px solid var(--accent);
+  border-color: var(--accent);
 }
 
 .btn-outline:hover:not(:disabled) {
-  background: var(--accent);
-  color: white;
+  background: var(--accent-light);
+  color: var(--accent);
+  text-decoration: none;
 }
 
 .btn-danger {
   background: transparent;
   color: var(--error);
-  border: 1px solid var(--error);
+  border-color: var(--error);
 }
 
 .btn-danger:hover:not(:disabled) {
   background: var(--error);
-  color: white;
+  color: #fff;
+  text-decoration: none;
 }
 
 .btn-sm {
-  padding: 7px 14px;
+  padding: 4px 10px;
   font-size: 13px;
 }
 
 .btn-lg {
-  padding: 14px 32px;
-  font-size: 16px;
+  padding: 8px 20px;
+  font-size: 15px;
 }
 
 .btn-icon {
-  padding: 8px;
-  border-radius: var(--radius);
-  background: var(--bg-tertiary);
-  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all var(--transition-fast);
 }
 
 .btn-icon:hover {
-  background: var(--border);
+  background: var(--bg-tertiary);
   color: var(--text-primary);
+  border-color: var(--border-hover);
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px 12px;
-  border-radius: 20px;
+  gap: 3px;
+  padding: 2px 6px;
+  border-radius: var(--radius);
   font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.3px;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.4;
 }
 
 .badge-success {
@@ -148,23 +151,28 @@
 
 .form-input {
   width: 100%;
-  padding: 12px 16px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border);
+  padding: 6px 12px;
+  background: var(--bg-card);
+  border: 1px solid #BFBFBF;
   border-radius: var(--radius);
   color: var(--text-primary);
   font-size: 14px;
-  transition: all var(--transition);
+  font-family: inherit;
+  transition: border-color var(--transition-fast);
   outline: none;
 }
 
 .form-input:focus {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-light);
+  box-shadow: none;
 }
 
 .form-input::placeholder {
   color: var(--text-muted);
+}
+
+[data-theme="dark"] .form-input {
+  border-color: var(--border-hover);
 }
 
 .form-textarea {
@@ -174,13 +182,15 @@
 
 .form-select {
   appearance: none;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%239ca1af' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23767676' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 12px center;
+  background-position: right 10px center;
+  padding-right: 30px;
 }
 
-[data-theme="light"] .form-select {
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+[data-theme="dark"] .form-select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239DA0A4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 }
 
 .search-input-wrapper {
@@ -191,33 +201,39 @@
 
 .search-input-wrapper svg {
   position: absolute;
-  left: 12px;
+  left: 10px;
   color: var(--text-muted);
 }
 
 .search-input-wrapper input {
-  padding-left: 40px;
+  padding-left: 32px;
 }
 
 .tag-chip {
   display: inline-flex;
   align-items: center;
-  padding: 3px 10px;
-  border-radius: 8px;
+  padding: 2px 6px;
+  border-radius: var(--radius);
   font-size: 12px;
-  font-weight: 500;
-  background: var(--accent-light);
-  color: var(--accent);
+  font-weight: 400;
+  background: var(--bg-tertiary);
+  color: #666;
+  border: none;
+  line-height: 1.4;
+}
+
+[data-theme="dark"] .tag-chip {
+  color: var(--text-secondary);
 }
 
 .tag-chip.small {
-  padding: 2px 6px;
+  padding: 1px 4px;
   font-size: 11px;
 }
 
 .tag-chip.active {
   background: var(--accent);
-  color: white;
+  color: #fff;
 }
 
 .tag-chip.success {
@@ -253,25 +269,27 @@
 
 .admin-table th,
 .admin-table td {
-  padding: 12px 16px;
+  padding: 0 12px;
+  height: 40px;
   text-align: left;
   border-bottom: 1px solid var(--border);
+  font-size: 14px;
 }
 
 .admin-table th {
   font-size: 13px;
   font-weight: 600;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+  color: var(--text-primary);
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .admin-table tbody tr {
-  transition: background-color var(--transition);
+  transition: background-color var(--transition-fast);
 }
 
 .admin-table tbody tr:hover {
-  background: var(--bg-card-hover);
+  background: var(--bg-tertiary);
 }
 
 .admin-table tbody tr:last-child td {
@@ -282,37 +300,51 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  padding: 20px 0;
+  gap: 4px;
+  padding: 16px 0;
 }
 
 .pagination span {
   color: var(--text-secondary);
-  font-size: 14px;
+  font-size: 13px;
+  padding: 0 8px;
 }
 
 .pagination button {
-  padding: 8px 16px;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
   border-radius: var(--radius);
   border: 1px solid var(--border);
-  background: var(--bg-tertiary);
+  background: var(--bg-card);
   color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
 }
 
 .pagination button:hover:not(:disabled) {
-  background: var(--border);
+  background: var(--bg-tertiary);
+  border-color: var(--border-hover);
 }
 
 .pagination button:disabled {
-  opacity: 0.4;
+  opacity: 0.5;
   cursor: not-allowed;
+}
+
+.pagination button.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
 }
 
 .filter-bar {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 16px 0;
+  padding: 12px 0;
+  flex-wrap: wrap;
 }
 
 .empty-page {
@@ -331,19 +363,12 @@
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
+  background: rgba(0, 0, 0, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
   z-index: 1000;
   animation: fadeIn 0.2s ease-out;
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
 }
 
 .modal-content {
@@ -353,21 +378,22 @@
   box-shadow: var(--shadow-lg);
   max-width: 480px;
   width: 90%;
-  animation: scale-in 0.25s ease-out;
+  animation: scale-in 0.2s ease-out;
 }
 
 .admin-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
 }
 
 .admin-header h1 {
   display: flex;
   align-items: center;
-  gap: 12px;
-  font-size: 22px;
+  gap: 8px;
+  font-size: 20px;
+  font-weight: 600;
 }
 
 .cell-value {
@@ -375,7 +401,7 @@
 }
 
 .admin-page {
-  animation: fadeInUp 0.3s ease-out;
+  animation: fadeInUp 0.25s ease-out;
 }
 
 .progress-bar {
@@ -387,7 +413,7 @@
 
 .progress-bar-fill {
   height: 100%;
-  background: linear-gradient(90deg, var(--accent), #8b5cf6);
+  background: var(--accent);
   border-radius: 3px;
   transition: width var(--transition);
 }

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -1,4 +1,360 @@
-.btn {
+/* ═══════════════════════════════════════════════════
+   Default Theme  — 主分支默认风格
+   ═══════════════════════════════════════════════════ */
+[data-theme-style="default"] .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 11px 22px;
+  border: none;
+  border-radius: var(--radius);
+  font-size: 14px;
+  font-weight: 600;
+  transition: all var(--transition);
+  text-decoration: none;
+  cursor: pointer;
+  position: relative;
+  overflow: hidden;
+}
+
+[data-theme-style="default"] .btn::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.1) 0%, transparent 50%);
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+[data-theme-style="default"] .btn:hover::before {
+  opacity: 1;
+}
+
+[data-theme-style="default"] .btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+[data-theme-style="default"] .btn-primary {
+  background: linear-gradient(135deg, var(--accent), #8b5cf6);
+  color: white;
+  box-shadow: var(--shadow-accent);
+}
+
+[data-theme-style="default"] .btn-primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg), var(--shadow-accent);
+}
+
+[data-theme-style="default"] .btn-secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+}
+
+[data-theme-style="default"] .btn-secondary:hover:not(:disabled) {
+  background: var(--border);
+  border-color: var(--border-hover);
+}
+
+[data-theme-style="default"] .btn-outline {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+}
+
+[data-theme-style="default"] .btn-outline:hover:not(:disabled) {
+  background: var(--accent);
+  color: white;
+}
+
+[data-theme-style="default"] .btn-danger {
+  background: transparent;
+  color: var(--error);
+  border: 1px solid var(--error);
+}
+
+[data-theme-style="default"] .btn-danger:hover:not(:disabled) {
+  background: var(--error);
+  color: white;
+}
+
+[data-theme-style="default"] .btn-sm {
+  padding: 7px 14px;
+  font-size: 13px;
+}
+
+[data-theme-style="default"] .btn-lg {
+  padding: 14px 32px;
+  font-size: 16px;
+}
+
+[data-theme-style="default"] .btn-icon {
+  padding: 8px;
+  border-radius: var(--radius);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+
+[data-theme-style="default"] .btn-icon:hover {
+  background: var(--border);
+  color: var(--text-primary);
+}
+
+[data-theme-style="default"] .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+[data-theme-style="default"] .form-input {
+  width: 100%;
+  padding: 12px 16px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-primary);
+  font-size: 14px;
+  transition: all var(--transition);
+  outline: none;
+}
+
+[data-theme-style="default"] .form-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-light);
+}
+
+[data-theme-style="default"] .form-input::placeholder {
+  color: var(--text-muted);
+}
+
+[data-theme-style="default"] .form-select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%239ca1af' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+}
+
+[data-theme-style="default"][data-theme="light"] .form-select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+}
+
+[data-theme-style="default"] .search-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+[data-theme-style="default"] .search-input-wrapper svg {
+  position: absolute;
+  left: 12px;
+  color: var(--text-muted);
+}
+
+[data-theme-style="default"] .search-input-wrapper input {
+  padding-left: 40px;
+}
+
+[data-theme-style="default"] .tag-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+[data-theme-style="default"] .tag-chip.small {
+  padding: 2px 6px;
+  font-size: 11px;
+}
+
+[data-theme-style="default"] .tag-chip.active {
+  background: var(--accent);
+  color: white;
+}
+
+[data-theme-style="default"] .tag-chip.success {
+  background: var(--success-bg);
+  color: var(--success);
+}
+
+[data-theme-style="default"] .tag-chip.error {
+  background: var(--error-bg);
+  color: var(--error);
+}
+
+[data-theme-style="default"] .tag-chip.warning {
+  background: var(--warning-bg);
+  color: var(--warning);
+}
+
+[data-theme-style="default"] .table-wrapper {
+  overflow-x: auto;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+}
+
+[data-theme-style="default"] .admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--bg-card);
+}
+
+[data-theme-style="default"] .admin-table thead {
+  background: var(--bg-tertiary);
+}
+
+[data-theme-style="default"] .admin-table th,
+[data-theme-style="default"] .admin-table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+[data-theme-style="default"] .admin-table th {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+[data-theme-style="default"] .admin-table tbody tr {
+  transition: background-color var(--transition);
+}
+
+[data-theme-style="default"] .admin-table tbody tr:hover {
+  background: var(--bg-card-hover);
+}
+
+[data-theme-style="default"] .admin-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+[data-theme-style="default"] .pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 20px 0;
+}
+
+[data-theme-style="default"] .pagination span {
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+[data-theme-style="default"] .pagination button {
+  padding: 8px 16px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+[data-theme-style="default"] .pagination button:hover:not(:disabled) {
+  background: var(--border);
+}
+
+[data-theme-style="default"] .pagination button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+[data-theme-style="default"] .filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 16px 0;
+}
+
+[data-theme-style="default"] .empty-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  color: var(--text-muted);
+}
+
+[data-theme-style="default"] .empty-page p {
+  margin-top: 8px;
+}
+
+[data-theme-style="default"] .modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease-out;
+}
+
+[data-theme-style="default"] .modal-content {
+  background: var(--bg-card);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-lg);
+  max-width: 480px;
+  width: 90%;
+  animation: scale-in 0.25s ease-out;
+}
+
+[data-theme-style="default"] .admin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+[data-theme-style="default"] .admin-header h1 {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 22px;
+}
+
+[data-theme-style="default"] .cell-value {
+  color: var(--text-secondary);
+}
+
+[data-theme-style="default"] .admin-page {
+  animation: fadeInUp 0.3s ease-out;
+}
+
+[data-theme-style="default"] .progress-bar {
+  height: 6px;
+  background: var(--bg-tertiary);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+[data-theme-style="default"] .progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), #8b5cf6);
+  border-radius: 3px;
+  transition: width var(--transition);
+}
+
+/* ═══════════════════════════════════════════════════
+   Luogu Theme  — 洛谷风格复刻（默认）
+   ═══════════════════════════════════════════════════ */
+:root .btn,
+[data-theme-style="luogu"] .btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -16,72 +372,84 @@
   white-space: nowrap;
 }
 
-.btn:disabled {
+:root .btn:disabled,
+[data-theme-style="luogu"] .btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.btn-primary {
+:root .btn-primary,
+[data-theme-style="luogu"] .btn-primary {
   background: var(--accent);
   color: #fff;
   border-color: var(--accent);
 }
 
-.btn-primary:hover:not(:disabled) {
+:root .btn-primary:hover:not(:disabled),
+[data-theme-style="luogu"] .btn-primary:hover:not(:disabled) {
   background: var(--accent-hover);
   border-color: var(--accent-hover);
   color: #fff;
   text-decoration: none;
 }
 
-.btn-secondary {
+:root .btn-secondary,
+[data-theme-style="luogu"] .btn-secondary {
   background: var(--bg-secondary);
   color: var(--text-primary);
   border-color: var(--border);
 }
 
-.btn-secondary:hover:not(:disabled) {
+:root .btn-secondary:hover:not(:disabled),
+[data-theme-style="luogu"] .btn-secondary:hover:not(:disabled) {
   background: var(--bg-tertiary);
   border-color: var(--border-hover);
   color: var(--text-primary);
   text-decoration: none;
 }
 
-.btn-outline {
+:root .btn-outline,
+[data-theme-style="luogu"] .btn-outline {
   background: transparent;
   color: var(--accent);
   border-color: var(--accent);
 }
 
-.btn-outline:hover:not(:disabled) {
+:root .btn-outline:hover:not(:disabled),
+[data-theme-style="luogu"] .btn-outline:hover:not(:disabled) {
   background: var(--accent-light);
   color: var(--accent);
   text-decoration: none;
 }
 
-.btn-danger {
+:root .btn-danger,
+[data-theme-style="luogu"] .btn-danger {
   background: transparent;
   color: var(--error);
   border-color: var(--error);
 }
 
-.btn-danger:hover:not(:disabled) {
+:root .btn-danger:hover:not(:disabled),
+[data-theme-style="luogu"] .btn-danger:hover:not(:disabled) {
   background: var(--error);
   color: #fff;
   text-decoration: none;
 }
 
-.btn-sm {
+:root .btn-sm,
+[data-theme-style="luogu"] .btn-sm {
   padding: 4px 10px;
   font-size: 13px;
 }
 
-.btn-lg {
+:root .btn-lg,
+[data-theme-style="luogu"] .btn-lg {
   padding: 8px 20px;
   font-size: 15px;
 }
 
-.btn-icon {
+:root .btn-icon,
+[data-theme-style="luogu"] .btn-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -96,13 +464,15 @@
   transition: all var(--transition-fast);
 }
 
-.btn-icon:hover {
+:root .btn-icon:hover,
+[data-theme-style="luogu"] .btn-icon:hover {
   background: var(--bg-tertiary);
   color: var(--text-primary);
   border-color: var(--border-hover);
 }
 
-.badge {
+:root .badge,
+[data-theme-style="luogu"] .badge {
   display: inline-flex;
   align-items: center;
   gap: 3px;
@@ -114,42 +484,50 @@
   line-height: 1.4;
 }
 
-.badge-success {
+:root .badge-success,
+[data-theme-style="luogu"] .badge-success {
   background: var(--success-bg);
   color: var(--success);
 }
 
-.badge-error {
+:root .badge-error,
+[data-theme-style="luogu"] .badge-error {
   background: var(--error-bg);
   color: var(--error);
 }
 
-.badge-warning {
+:root .badge-warning,
+[data-theme-style="luogu"] .badge-warning {
   background: var(--warning-bg);
   color: var(--warning);
 }
 
-.badge-info {
+:root .badge-info,
+[data-theme-style="luogu"] .badge-info {
   background: var(--info-bg);
   color: var(--info);
 }
 
-.badge-gold {
+:root .badge-gold,
+[data-theme-style="luogu"] .badge-gold {
   background: var(--gold-bg);
   color: var(--gold);
 }
 
-.badge-silver {
+:root .badge-silver,
+[data-theme-style="luogu"] .badge-silver {
   background: var(--silver-bg);
   color: var(--silver);
 }
 
-.badge-bronze {
+:root .badge-bronze,
+[data-theme-style="luogu"] .badge-bronze {
   background: var(--bronze-bg);
   color: var(--bronze);
 }
 
-.form-input {
+:root .form-input,
+[data-theme-style="luogu"] .form-input {
   width: 100%;
   padding: 6px 12px;
   background: var(--bg-card);
@@ -162,25 +540,30 @@
   outline: none;
 }
 
-.form-input:focus {
+:root .form-input:focus,
+[data-theme-style="luogu"] .form-input:focus {
   border-color: var(--accent);
   box-shadow: none;
 }
 
-.form-input::placeholder {
+:root .form-input::placeholder,
+[data-theme-style="luogu"] .form-input::placeholder {
   color: var(--text-muted);
 }
 
-[data-theme="dark"] .form-input {
+:root [data-theme="dark"] .form-input,
+[data-theme-style="luogu"][data-theme="dark"] .form-input {
   border-color: var(--border-hover);
 }
 
-.form-textarea {
+:root .form-textarea,
+[data-theme-style="luogu"] .form-textarea {
   min-height: 100px;
   resize: vertical;
 }
 
-.form-select {
+:root .form-select,
+[data-theme-style="luogu"] .form-select {
   appearance: none;
   -webkit-appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23767676' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
@@ -189,27 +572,32 @@
   padding-right: 30px;
 }
 
-[data-theme="dark"] .form-select {
+:root [data-theme="dark"] .form-select,
+[data-theme-style="luogu"][data-theme="dark"] .form-select {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%239DA0A4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
 }
 
-.search-input-wrapper {
+:root .search-input-wrapper,
+[data-theme-style="luogu"] .search-input-wrapper {
   position: relative;
   display: flex;
   align-items: center;
 }
 
-.search-input-wrapper svg {
+:root .search-input-wrapper svg,
+[data-theme-style="luogu"] .search-input-wrapper svg {
   position: absolute;
   left: 10px;
   color: var(--text-muted);
 }
 
-.search-input-wrapper input {
+:root .search-input-wrapper input,
+[data-theme-style="luogu"] .search-input-wrapper input {
   padding-left: 32px;
 }
 
-.tag-chip {
+:root .tag-chip,
+[data-theme-style="luogu"] .tag-chip {
   display: inline-flex;
   align-items: center;
   padding: 2px 6px;
@@ -222,53 +610,64 @@
   line-height: 1.4;
 }
 
-[data-theme="dark"] .tag-chip {
+:root [data-theme="dark"] .tag-chip,
+[data-theme-style="luogu"][data-theme="dark"] .tag-chip {
   color: var(--text-secondary);
 }
 
-.tag-chip.small {
+:root .tag-chip.small,
+[data-theme-style="luogu"] .tag-chip.small {
   padding: 1px 4px;
   font-size: 11px;
 }
 
-.tag-chip.active {
+:root .tag-chip.active,
+[data-theme-style="luogu"] .tag-chip.active {
   background: var(--accent);
   color: #fff;
 }
 
-.tag-chip.success {
+:root .tag-chip.success,
+[data-theme-style="luogu"] .tag-chip.success {
   background: var(--success-bg);
   color: var(--success);
 }
 
-.tag-chip.error {
+:root .tag-chip.error,
+[data-theme-style="luogu"] .tag-chip.error {
   background: var(--error-bg);
   color: var(--error);
 }
 
-.tag-chip.warning {
+:root .tag-chip.warning,
+[data-theme-style="luogu"] .tag-chip.warning {
   background: var(--warning-bg);
   color: var(--warning);
 }
 
-.table-wrapper {
+:root .table-wrapper,
+[data-theme-style="luogu"] .table-wrapper {
   overflow-x: auto;
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
 }
 
-.admin-table {
+:root .admin-table,
+[data-theme-style="luogu"] .admin-table {
   width: 100%;
   border-collapse: collapse;
   background: var(--bg-card);
 }
 
-.admin-table thead {
+:root .admin-table thead,
+[data-theme-style="luogu"] .admin-table thead {
   background: var(--bg-tertiary);
 }
 
-.admin-table th,
-.admin-table td {
+:root .admin-table th,
+:root .admin-table td,
+[data-theme-style="luogu"] .admin-table th,
+[data-theme-style="luogu"] .admin-table td {
   padding: 0 12px;
   height: 40px;
   text-align: left;
@@ -276,7 +675,8 @@
   font-size: 14px;
 }
 
-.admin-table th {
+:root .admin-table th,
+[data-theme-style="luogu"] .admin-table th {
   font-size: 13px;
   font-weight: 600;
   color: var(--text-primary);
@@ -284,19 +684,23 @@
   letter-spacing: 0;
 }
 
-.admin-table tbody tr {
+:root .admin-table tbody tr,
+[data-theme-style="luogu"] .admin-table tbody tr {
   transition: background-color var(--transition-fast);
 }
 
-.admin-table tbody tr:hover {
+:root .admin-table tbody tr:hover,
+[data-theme-style="luogu"] .admin-table tbody tr:hover {
   background: var(--bg-tertiary);
 }
 
-.admin-table tbody tr:last-child td {
+:root .admin-table tbody tr:last-child td,
+[data-theme-style="luogu"] .admin-table tbody tr:last-child td {
   border-bottom: none;
 }
 
-.pagination {
+:root .pagination,
+[data-theme-style="luogu"] .pagination {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -304,13 +708,15 @@
   padding: 16px 0;
 }
 
-.pagination span {
+:root .pagination span,
+[data-theme-style="luogu"] .pagination span {
   color: var(--text-secondary);
   font-size: 13px;
   padding: 0 8px;
 }
 
-.pagination button {
+:root .pagination button,
+[data-theme-style="luogu"] .pagination button {
   min-width: 32px;
   height: 32px;
   padding: 0 8px;
@@ -323,23 +729,27 @@
   transition: all var(--transition-fast);
 }
 
-.pagination button:hover:not(:disabled) {
+:root .pagination button:hover:not(:disabled),
+[data-theme-style="luogu"] .pagination button:hover:not(:disabled) {
   background: var(--bg-tertiary);
   border-color: var(--border-hover);
 }
 
-.pagination button:disabled {
+:root .pagination button:disabled,
+[data-theme-style="luogu"] .pagination button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.pagination button.active {
+:root .pagination button.active,
+[data-theme-style="luogu"] .pagination button.active {
   background: var(--accent);
   color: #fff;
   border-color: var(--accent);
 }
 
-.filter-bar {
+:root .filter-bar,
+[data-theme-style="luogu"] .filter-bar {
   display: flex;
   align-items: center;
   gap: 12px;
@@ -347,7 +757,8 @@
   flex-wrap: wrap;
 }
 
-.empty-page {
+:root .empty-page,
+[data-theme-style="luogu"] .empty-page {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -356,11 +767,13 @@
   color: var(--text-muted);
 }
 
-.empty-page p {
+:root .empty-page p,
+[data-theme-style="luogu"] .empty-page p {
   margin-top: 8px;
 }
 
-.modal-overlay {
+:root .modal-overlay,
+[data-theme-style="luogu"] .modal-overlay {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.5);
@@ -371,7 +784,8 @@
   animation: fadeIn 0.2s ease-out;
 }
 
-.modal-content {
+:root .modal-content,
+[data-theme-style="luogu"] .modal-content {
   background: var(--bg-card);
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
@@ -381,14 +795,16 @@
   animation: scale-in 0.2s ease-out;
 }
 
-.admin-header {
+:root .admin-header,
+[data-theme-style="luogu"] .admin-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 16px;
 }
 
-.admin-header h1 {
+:root .admin-header h1,
+[data-theme-style="luogu"] .admin-header h1 {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -396,22 +812,26 @@
   font-weight: 600;
 }
 
-.cell-value {
+:root .cell-value,
+[data-theme-style="luogu"] .cell-value {
   color: var(--text-secondary);
 }
 
-.admin-page {
+:root .admin-page,
+[data-theme-style="luogu"] .admin-page {
   animation: fadeInUp 0.25s ease-out;
 }
 
-.progress-bar {
+:root .progress-bar,
+[data-theme-style="luogu"] .progress-bar {
   height: 6px;
   background: var(--bg-tertiary);
   border-radius: 3px;
   overflow: hidden;
 }
 
-.progress-bar-fill {
+:root .progress-bar-fill,
+[data-theme-style="luogu"] .progress-bar-fill {
   height: 100%;
   background: var(--accent);
   border-radius: 3px;
@@ -419,7 +839,8 @@
 }
 
 /* ── Luogu-style page title with left accent bar ── */
-.page-title {
+:root .page-title,
+[data-theme-style="luogu"] .page-title {
   font-size: 22px;
   font-weight: 700;
   margin: 0;
@@ -427,7 +848,8 @@
   padding-left: 12px;
 }
 
-.page-title::before {
+:root .page-title::before,
+[data-theme-style="luogu"] .page-title::before {
   content: '';
   position: absolute;
   left: 0;
@@ -440,7 +862,8 @@
 }
 
 /* ── Luogu-style section/card header with left accent bar ── */
-.section-title {
+:root .section-title,
+[data-theme-style="luogu"] .section-title {
   position: relative;
   padding-left: 10px;
   font-size: 15px;
@@ -448,7 +871,8 @@
   margin: 0;
 }
 
-.section-title::before {
+:root .section-title::before,
+[data-theme-style="luogu"] .section-title::before {
   content: '';
   position: absolute;
   left: 0;
@@ -458,4 +882,364 @@
   height: 14px;
   background: var(--accent);
   border-radius: 2px;
+}
+
+/* ═══════════════════════════════════════════════════
+   Hydro Theme  — HydroOJ 风格组件
+   ═══════════════════════════════════════════════════ */
+[data-theme-style="hydro"] .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 7px 16px;
+  border: 1px solid var(--border);
+  border-radius: 0;
+  font-size: 14px;
+  font-weight: 400;
+  font-family: inherit;
+  transition: all var(--transition-fast);
+  text-decoration: none;
+  cursor: pointer;
+  position: relative;
+  white-space: nowrap;
+  line-height: 1.4;
+}
+
+[data-theme-style="hydro"] .btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+[data-theme-style="hydro"] .btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+[data-theme-style="hydro"] .btn-primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
+  color: #fff;
+  text-decoration: none;
+}
+
+[data-theme-style="hydro"] .btn-secondary {
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+
+[data-theme-style="hydro"] .btn-secondary:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+  border-color: var(--border-hover);
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+[data-theme-style="hydro"] .btn-outline {
+  background: transparent;
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+[data-theme-style="hydro"] .btn-outline:hover:not(:disabled) {
+  background: var(--accent-light);
+  color: var(--accent);
+  text-decoration: none;
+}
+
+[data-theme-style="hydro"] .btn-danger {
+  background: transparent;
+  color: var(--error);
+  border-color: var(--error);
+}
+
+[data-theme-style="hydro"] .btn-danger:hover:not(:disabled) {
+  background: var(--error);
+  color: #fff;
+  text-decoration: none;
+}
+
+[data-theme-style="hydro"] .btn-sm {
+  padding: 4px 10px;
+  font-size: 13px;
+}
+
+[data-theme-style="hydro"] .btn-lg {
+  padding: 10px 24px;
+  font-size: 15px;
+}
+
+[data-theme-style="hydro"] .btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  border-radius: 0;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+[data-theme-style="hydro"] .btn-icon:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--border-hover);
+}
+
+[data-theme-style="hydro"] .badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 8px;
+  border-radius: 0;
+  font-size: 12px;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.4;
+}
+
+[data-theme-style="hydro"] .form-input {
+  width: 100%;
+  padding: 7px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 0;
+  color: var(--text-primary);
+  font-size: 14px;
+  font-family: inherit;
+  transition: border-color var(--transition-fast);
+  outline: none;
+  line-height: 1.4;
+}
+
+[data-theme-style="hydro"] .form-input:focus {
+  border-color: var(--accent);
+  box-shadow: none;
+}
+
+[data-theme-style="hydro"] .form-input::placeholder {
+  color: var(--text-muted);
+}
+
+[data-theme-style="hydro"] .form-textarea {
+  min-height: 100px;
+  resize: vertical;
+}
+
+[data-theme-style="hydro"] .form-select {
+  appearance: none;
+  -webkit-appearance: none;
+  border-radius: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23767676' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 30px;
+}
+
+[data-theme-style="hydro"] .search-input-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+[data-theme-style="hydro"] .search-input-wrapper svg {
+  position: absolute;
+  left: 10px;
+  color: var(--text-muted);
+}
+
+[data-theme-style="hydro"] .search-input-wrapper input {
+  padding-left: 32px;
+}
+
+[data-theme-style="hydro"] .tag-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 0;
+  font-size: 12px;
+  font-weight: 400;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-light);
+  line-height: 1.4;
+}
+
+[data-theme-style="hydro"] .tag-chip.small {
+  padding: 1px 4px;
+  font-size: 11px;
+}
+
+[data-theme-style="hydro"] .tag-chip.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+[data-theme-style="hydro"] .tag-chip.success {
+  background: var(--success-bg);
+  color: var(--success);
+}
+
+[data-theme-style="hydro"] .tag-chip.error {
+  background: var(--error-bg);
+  color: var(--error);
+}
+
+[data-theme-style="hydro"] .tag-chip.warning {
+  background: var(--warning-bg);
+  color: var(--warning);
+}
+
+[data-theme-style="hydro"] .table-wrapper {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+}
+
+[data-theme-style="hydro"] .admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--bg-card);
+}
+
+[data-theme-style="hydro"] .admin-table thead {
+  background: var(--bg-tertiary);
+}
+
+[data-theme-style="hydro"] .admin-table th,
+[data-theme-style="hydro"] .admin-table td {
+  padding: 0 12px;
+  height: 40px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  font-size: 14px;
+}
+
+[data-theme-style="hydro"] .admin-table th {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+[data-theme-style="hydro"] .admin-table tbody tr {
+  transition: background-color var(--transition-fast);
+}
+
+[data-theme-style="hydro"] .admin-table tbody tr:hover {
+  background: var(--bg-tertiary);
+}
+
+[data-theme-style="hydro"] .admin-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+[data-theme-style="hydro"] .pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 16px 0;
+}
+
+[data-theme-style="hydro"] .pagination span {
+  color: var(--text-secondary);
+  font-size: 13px;
+  padding: 0 8px;
+}
+
+[data-theme-style="hydro"] .pagination button {
+  min-width: 32px;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+[data-theme-style="hydro"] .pagination button:hover:not(:disabled) {
+  background: var(--bg-tertiary);
+  border-color: var(--border-hover);
+}
+
+[data-theme-style="hydro"] .pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+[data-theme-style="hydro"] .pagination button.active {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+[data-theme-style="hydro"] .filter-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  flex-wrap: wrap;
+}
+
+[data-theme-style="hydro"] .modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  animation: fadeIn 0.2s ease-out;
+}
+
+[data-theme-style="hydro"] .modal-content {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-lg);
+  max-width: 480px;
+  width: 90%;
+  animation: scale-in 0.2s ease-out;
+}
+
+[data-theme-style="hydro"] .admin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+[data-theme-style="hydro"] .admin-header h1 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+[data-theme-style="hydro"] .admin-page {
+  animation: fadeInUp 0.25s ease-out;
+}
+
+[data-theme-style="hydro"] .progress-bar {
+  height: 6px;
+  background: var(--bg-tertiary);
+  border-radius: 0;
+  overflow: hidden;
+}
+
+[data-theme-style="hydro"] .progress-bar-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 0;
+  transition: width var(--transition);
 }

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -417,3 +417,45 @@
   border-radius: 3px;
   transition: width var(--transition);
 }
+
+/* ── Luogu-style page title with left accent bar ── */
+.page-title {
+  font-size: 22px;
+  font-weight: 700;
+  margin: 0;
+  position: relative;
+  padding-left: 12px;
+}
+
+.page-title::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4px;
+  height: 18px;
+  background: var(--accent);
+  border-radius: 2px;
+}
+
+/* ── Luogu-style section/card header with left accent bar ── */
+.section-title {
+  position: relative;
+  padding-left: 10px;
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.section-title::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 14px;
+  background: var(--accent);
+  border-radius: 2px;
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -39,9 +39,12 @@
   --diff-noi: #0E1D69;
   --header-gradient: linear-gradient(90deg, #5BA5C5, #CF94C5);
   --radius: 3px;
+  --radius-md: 3px;
   --radius-lg: 4px;
   --radius-xl: 6px;
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.08);
   --shadow-lg: 0 2px 8px rgba(0, 0, 0, 0.08);
   --shadow-accent: none;
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04);
@@ -82,6 +85,8 @@
   --bronze: #A0785A;
   --bronze-bg: rgba(160, 120, 90, 0.15);
   --shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.4);
   --shadow-lg: 0 2px 8px rgba(0, 0, 0, 0.4);
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3);
 }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,80 +1,89 @@
 :root {
-  --bg-primary: #0a0b0f;
-  --bg-secondary: #12141c;
-  --bg-tertiary: #1a1d26;
-  --bg-card: #161821;
-  --bg-card-hover: #1d202b;
-  --text-primary: #f1f2f5;
-  --text-secondary: #9ca1af;
-  --text-muted: #5c6078;
-  --accent: #6366f1;
-  --accent-hover: #4f46e5;
-  --accent-light: rgba(99, 102, 241, 0.12);
-  --accent-glow: rgba(99, 102, 241, 0.3);
-  --success: #22c55e;
-  --success-bg: rgba(34, 197, 94, 0.12);
-  --warning: #f59e0b;
-  --warning-bg: rgba(245, 158, 11, 0.12);
-  --error: #ef4444;
-  --error-bg: rgba(239, 68, 68, 0.12);
-  --info: #3b82f6;
-  --info-bg: rgba(59, 130, 246, 0.12);
-  --border: #252936;
-  --border-light: #313548;
-  --border-hover: #3d4156;
-  --gold: #fbbf24;
-  --gold-bg: rgba(251, 191, 36, 0.12);
-  --silver: #94a3b8;
-  --silver-bg: rgba(148, 163, 184, 0.1);
-  --bronze: #cd7f32;
-  --bronze-bg: rgba(205, 127, 50, 0.12);
-  --radius: 10px;
-  --radius-lg: 16px;
-  --radius-xl: 20px;
-  --shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
-  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.5);
-  --shadow-accent: 0 0 20px rgba(99, 102, 241, 0.15);
-  --shadow-card: 0 8px 28px rgba(0, 0, 0, 0.4);
-  --transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-  --transition-fast: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
-  --backdrop-blur: blur(20px);
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, monospace;
+  --bg-primary: #F5F5F5;
+  --bg-secondary: #FFFFFF;
+  --bg-tertiary: #F0F0F0;
+  --bg-card: #FFFFFF;
+  --bg-card-hover: #FAFAFA;
+  --text-primary: #404040;
+  --text-secondary: #767676;
+  --text-muted: #B8B8B8;
+  --accent: #3498DB;
+  --accent-hover: #2980B9;
+  --accent-light: rgba(52, 152, 219, 0.1);
+  --accent-glow: rgba(52, 152, 219, 0.25);
+  --success: #52C41A;
+  --success-bg: rgba(82, 196, 26, 0.1);
+  --warning: #F39C12;
+  --warning-bg: rgba(243, 156, 18, 0.1);
+  --error: #FE4C61;
+  --error-bg: rgba(254, 76, 97, 0.1);
+  --info: #13C2C2;
+  --info-bg: rgba(19, 194, 194, 0.1);
+  --border: #E0E0E0;
+  --border-light: #F0F0F0;
+  --border-hover: #BFBFBF;
+  --gold: #F39C12;
+  --gold-bg: rgba(243, 156, 18, 0.1);
+  --silver: #909399;
+  --silver-bg: rgba(144, 147, 153, 0.1);
+  --bronze: #9C6B3F;
+  --bronze-bg: rgba(156, 107, 63, 0.1);
+  --diff-none: #BFBFBF;
+  --diff-easy: #FE4C61;
+  --diff-easy-mid: #F39C11;
+  --diff-mid: #FFC116;
+  --diff-hard: #52C41A;
+  --diff-hard-plus: #52C41A;
+  --diff-province: #3498DB;
+  --diff-province-plus: #9D3DCF;
+  --diff-noi: #0E1D69;
+  --header-gradient: linear-gradient(90deg, #5BA5C5, #CF94C5);
+  --radius: 3px;
+  --radius-lg: 4px;
+  --radius-xl: 6px;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-lg: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --shadow-accent: none;
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --transition: 0.15s ease;
+  --transition-fast: 0.1s ease;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Helvetica Neue", "PingFang SC", "Noto Sans SC", "Segoe UI", Arial, "Microsoft YaHei", sans-serif;
+  --font-mono: "Fira Code", "Consolas", "Monaco", monospace;
 }
 
-[data-theme="light"] {
-  --bg-primary: #f8fafc;
-  --bg-secondary: #ffffff;
-  --bg-tertiary: #f1f5f9;
-  --bg-card: #ffffff;
-  --bg-card-hover: #f8fafc;
-  --text-primary: #0f172a;
-  --text-secondary: #475569;
-  --text-muted: #94a3b8;
-  --accent: #4f46e5;
-  --accent-hover: #4338ca;
-  --accent-light: rgba(79, 70, 229, 0.08);
-  --accent-glow: rgba(79, 70, 229, 0.2);
-  --success: #16a34a;
-  --success-bg: rgba(22, 163, 74, 0.08);
-  --warning: #d97706;
-  --warning-bg: rgba(217, 119, 6, 0.08);
-  --error: #dc2626;
-  --error-bg: rgba(220, 38, 38, 0.08);
-  --info: #2563eb;
-  --info-bg: rgba(37, 99, 235, 0.08);
-  --border: #e2e8f0;
-  --border-light: #cbd5e1;
-  --border-hover: #94a3b8;
-  --gold: #b45309;
-  --gold-bg: rgba(180, 83, 9, 0.08);
-  --silver: #64748b;
-  --silver-bg: rgba(100, 116, 139, 0.06);
-  --bronze: #92400e;
-  --bronze-bg: rgba(146, 64, 14, 0.08);
-  --shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
-  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.1);
-  --shadow-accent: 0 0 20px rgba(79, 70, 229, 0.1);
-  --shadow-card: 0 8px 28px rgba(0, 0, 0, 0.08);
+[data-theme="dark"] {
+  --bg-primary: #1E1E1E;
+  --bg-secondary: #252526;
+  --bg-tertiary: #2D2D2D;
+  --bg-card: #252526;
+  --bg-card-hover: #2D2D2D;
+  --text-primary: #DCDCDC;
+  --text-secondary: #9DA0A4;
+  --text-muted: #6B6B6B;
+  --accent: #3498DB;
+  --accent-hover: #5DADE2;
+  --accent-light: rgba(52, 152, 219, 0.15);
+  --accent-glow: rgba(52, 152, 219, 0.3);
+  --success: #67C23A;
+  --success-bg: rgba(103, 194, 58, 0.15);
+  --warning: #E6A23C;
+  --warning-bg: rgba(230, 162, 60, 0.15);
+  --error: #F56C6C;
+  --error-bg: rgba(245, 108, 108, 0.15);
+  --info: #409EFF;
+  --info-bg: rgba(64, 158, 255, 0.15);
+  --border: #3C3C3C;
+  --border-light: #2D2D2D;
+  --border-hover: #4A4A4A;
+  --gold: #E6A23C;
+  --gold-bg: rgba(230, 162, 60, 0.15);
+  --silver: #909399;
+  --silver-bg: rgba(144, 147, 153, 0.15);
+  --bronze: #A0785A;
+  --bronze-bg: rgba(160, 120, 90, 0.15);
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-lg: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
 * {
@@ -88,49 +97,36 @@ html {
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-family: var(--font-sans);
   background-color: var(--bg-primary);
   color: var(--text-primary);
-  line-height: 1.6;
+  font-size: 14px;
+  line-height: 1.5;
   min-height: 100vh;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-body::before {
-  content: '';
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: 
-    radial-gradient(ellipse at 20% 20%, rgba(99, 102, 241, 0.08) 0%, transparent 50%),
-    radial-gradient(ellipse at 80% 80%, rgba(139, 92, 246, 0.06) 0%, transparent 50%),
-    radial-gradient(ellipse at 50% 50%, rgba(59, 130, 246, 0.04) 0%, transparent 60%);
-  pointer-events: none;
-  z-index: -1;
-}
-
 a {
   color: var(--accent);
   text-decoration: none;
-  transition: color var(--transition);
+  transition: color var(--transition-fast);
 }
 
 a:hover {
   color: var(--accent-hover);
+  text-decoration: underline;
 }
 
 button {
   cursor: pointer;
   font-family: inherit;
-  transition: all var(--transition);
+  transition: all var(--transition-fast);
 }
 
 input, textarea, select {
   font-family: inherit;
-  transition: all var(--transition);
+  transition: all var(--transition-fast);
 }
 
 ::selection {
@@ -144,11 +140,11 @@ input, textarea, select {
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--bg-secondary);
+  background: var(--bg-tertiary);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--border-light);
+  background: var(--border-hover);
   border-radius: 4px;
 }
 
@@ -156,62 +152,26 @@ input, textarea, select {
   background: var(--text-muted);
 }
 
-.glass {
-  background: rgba(22, 24, 33, 0.7);
-  backdrop-filter: var(--backdrop-blur);
-  -webkit-backdrop-filter: var(--backdrop-blur);
-  border: 1px solid var(--border);
-}
-
-[data-theme="light"] .glass {
-  background: rgba(255, 255, 255, 0.8);
-}
-
 .card {
   background: var(--bg-card);
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-card);
-  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+  transition: box-shadow var(--transition-fast), border-color var(--transition-fast);
 }
 
 .card:hover {
   border-color: var(--border-hover);
   box-shadow: var(--shadow-lg);
-  transform: translateY(-2px);
-}
-
-.gradient-text {
-  background: linear-gradient(135deg, var(--accent), #8b5cf6);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.gradient-border {
-  position: relative;
-}
-
-.gradient-border::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(135deg, var(--accent), #8b5cf6);
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
 }
 
 .error-banner {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 14px 20px;
+  padding: 12px 16px;
   background: var(--error-bg);
-  border: 1px solid rgba(239, 68, 68, 0.25);
+  border: 1px solid var(--error);
   border-radius: var(--radius);
   color: var(--error);
   font-size: 14px;
@@ -229,11 +189,12 @@ input, textarea, select {
   gap: 16px;
   padding: 80px 0;
   text-align: center;
+  color: var(--text-secondary);
 }
 
 .loading-spinner {
-  width: 40px;
-  height: 40px;
+  width: 32px;
+  height: 32px;
   border: 3px solid var(--border);
   border-top-color: var(--accent);
   border-radius: 50%;
@@ -247,7 +208,7 @@ input, textarea, select {
 @keyframes fadeInUp {
   from {
     opacity: 0;
-    transform: translateY(10px);
+    transform: translateY(8px);
   }
   to {
     opacity: 1;
@@ -258,7 +219,7 @@ input, textarea, select {
 @keyframes slideIn {
   from {
     opacity: 0;
-    transform: translateX(-10px);
+    transform: translateX(-8px);
   }
   to {
     opacity: 1;
@@ -266,19 +227,10 @@ input, textarea, select {
   }
 }
 
-@keyframes pulse-glow {
-  0%, 100% {
-    box-shadow: 0 0 20px rgba(99, 102, 241, 0.3);
-  }
-  50% {
-    box-shadow: 0 0 30px rgba(99, 102, 241, 0.5);
-  }
-}
-
 @keyframes scale-in {
   from {
     opacity: 0;
-    transform: scale(0.95);
+    transform: scale(0.97);
   }
   to {
     opacity: 1;
@@ -286,20 +238,21 @@ input, textarea, select {
   }
 }
 
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 .animate-fade-in-up {
-  animation: fadeInUp 0.4s ease-out forwards;
+  animation: fadeInUp 0.25s ease-out forwards;
 }
 
 .animate-slide-in {
-  animation: slideIn 0.3s ease-out forwards;
-}
-
-.animate-pulse-glow {
-  animation: pulse-glow 2s ease-in-out infinite;
+  animation: slideIn 0.2s ease-out forwards;
 }
 
 .animate-scale-in {
-  animation: scale-in 0.25s ease-out forwards;
+  animation: scale-in 0.2s ease-out forwards;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -308,7 +261,6 @@ input, textarea, select {
   }
   .animate-fade-in-up,
   .animate-slide-in,
-  .animate-pulse-glow,
   .animate-scale-in {
     animation: none;
   }

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,4 +1,106 @@
-:root {
+/* ═══════════════════════════════════════════════════
+   Default Theme  — 主分支默认风格
+   ═══════════════════════════════════════════════════ */
+[data-theme-style="default"] {
+  --bg-primary: #0a0b0f;
+  --bg-secondary: #12141c;
+  --bg-tertiary: #1a1d26;
+  --bg-card: #161821;
+  --bg-card-hover: #1d202b;
+  --text-primary: #f1f2f5;
+  --text-secondary: #9ca1af;
+  --text-muted: #5c6078;
+  --accent: #6366f1;
+  --accent-hover: #4f46e5;
+  --accent-light: rgba(99, 102, 241, 0.12);
+  --accent-glow: rgba(99, 102, 241, 0.3);
+  --success: #22c55e;
+  --success-bg: rgba(34, 197, 94, 0.12);
+  --warning: #f59e0b;
+  --warning-bg: rgba(245, 158, 11, 0.12);
+  --error: #ef4444;
+  --error-bg: rgba(239, 68, 68, 0.12);
+  --info: #3b82f6;
+  --info-bg: rgba(59, 130, 246, 0.12);
+  --border: #252936;
+  --border-light: #313548;
+  --border-hover: #3d4156;
+  --gold: #fbbf24;
+  --gold-bg: rgba(251, 191, 36, 0.12);
+  --silver: #94a3b8;
+  --silver-bg: rgba(148, 163, 184, 0.1);
+  --bronze: #cd7f32;
+  --bronze-bg: rgba(205, 127, 50, 0.12);
+  --diff-none: #5c6078;
+  --diff-easy: #4ade80;
+  --diff-easy-mid: #fbbf24;
+  --diff-mid: #fbbf24;
+  --diff-hard: #ef4444;
+  --diff-hard-plus: #ef4444;
+  --diff-province: #3b82f6;
+  --diff-province-plus: #8b5cf6;
+  --diff-noi: #0E1D69;
+  --header-gradient: linear-gradient(135deg, var(--accent), #8b5cf6);
+  --radius: 10px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --radius-xl: 20px;
+  --shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
+  --shadow-sm: 0 4px 16px rgba(0, 0, 0, 0.35);
+  --shadow-md: 0 8px 28px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.5);
+  --shadow-accent: 0 0 20px rgba(99, 102, 241, 0.15);
+  --shadow-card: 0 8px 28px rgba(0, 0, 0, 0.4);
+  --transition: 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition-fast: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+  --backdrop-blur: blur(20px);
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, monospace;
+}
+
+[data-theme-style="default"][data-theme="light"] {
+  --bg-primary: #f8fafc;
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #f1f5f9;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f8fafc;
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+  --accent: #4f46e5;
+  --accent-hover: #4338ca;
+  --accent-light: rgba(79, 70, 229, 0.08);
+  --accent-glow: rgba(79, 70, 229, 0.2);
+  --success: #16a34a;
+  --success-bg: rgba(22, 163, 74, 0.08);
+  --warning: #d97706;
+  --warning-bg: rgba(217, 119, 6, 0.08);
+  --error: #dc2626;
+  --error-bg: rgba(220, 38, 38, 0.08);
+  --info: #2563eb;
+  --info-bg: rgba(37, 99, 235, 0.08);
+  --border: #e2e8f0;
+  --border-light: #cbd5e1;
+  --border-hover: #94a3b8;
+  --gold: #b45309;
+  --gold-bg: rgba(180, 83, 9, 0.08);
+  --silver: #64748b;
+  --silver-bg: rgba(100, 116, 139, 0.06);
+  --bronze: #92400e;
+  --bronze-bg: rgba(146, 64, 14, 0.08);
+  --shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
+  --shadow-sm: 0 4px 16px rgba(0, 0, 0, 0.06);
+  --shadow-md: 0 8px 28px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 12px 40px rgba(0, 0, 0, 0.1);
+  --shadow-accent: 0 0 20px rgba(79, 70, 229, 0.1);
+  --shadow-card: 0 8px 28px rgba(0, 0, 0, 0.08);
+}
+
+/* ═══════════════════════════════════════════════════
+   Luogu Theme  — 洛谷风格复刻
+   ═══════════════════════════════════════════════════ */
+:root,
+[data-theme-style="luogu"] {
   --bg-primary: #F5F5F5;
   --bg-secondary: #FFFFFF;
   --bg-tertiary: #F0F0F0;
@@ -54,7 +156,7 @@
   --font-mono: "Fira Code", "Consolas", "Monaco", monospace;
 }
 
-[data-theme="dark"] {
+[data-theme-style="luogu"][data-theme="dark"] {
   --bg-primary: #1E1E1E;
   --bg-secondary: #252526;
   --bg-tertiary: #2D2D2D;
@@ -91,6 +193,9 @@
   --shadow-card: 0 1px 2px rgba(0, 0, 0, 0.3);
 }
 
+/* ═══════════════════════════════════════════════════
+   Shared Base Styles
+   ═══════════════════════════════════════════════════ */
 * {
   margin: 0;
   padding: 0;
@@ -112,6 +217,22 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Default theme: dark gradient background glow */
+[data-theme-style="default"] body::before {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background:
+    radial-gradient(ellipse at 20% 20%, rgba(99, 102, 241, 0.08) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 80%, rgba(139, 92, 246, 0.06) 0%, transparent 50%),
+    radial-gradient(ellipse at 50% 50%, rgba(59, 130, 246, 0.04) 0%, transparent 60%);
+  pointer-events: none;
+  z-index: -1;
+}
+
 a {
   color: var(--accent);
   text-decoration: none;
@@ -121,6 +242,11 @@ a {
 a:hover {
   color: var(--accent-hover);
   text-decoration: underline;
+}
+
+/* Default theme: no underline on hover */
+[data-theme-style="default"] a:hover {
+  text-decoration: none;
 }
 
 button {
@@ -157,6 +283,14 @@ input, textarea, select {
   background: var(--text-muted);
 }
 
+/* Default theme: scrollbar track uses bg-secondary */
+[data-theme-style="default"] ::-webkit-scrollbar-track {
+  background: var(--bg-secondary);
+}
+
+/* ═══════════════════════════════════════════════════
+   Shared Utility Classes
+   ═══════════════════════════════════════════════════ */
 .card {
   background: var(--bg-card);
   border-radius: var(--radius-lg);
@@ -168,6 +302,55 @@ input, textarea, select {
 .card:hover {
   border-color: var(--border-hover);
   box-shadow: var(--shadow-lg);
+}
+
+/* Default theme: card hover has translateY and stronger shadow */
+[data-theme-style="default"] .card {
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+}
+
+[data-theme-style="default"] .card:hover {
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-lg);
+  transform: translateY(-2px);
+}
+
+/* Default theme: glass effect */
+[data-theme-style="default"] .glass {
+  background: rgba(22, 24, 33, 0.7);
+  backdrop-filter: var(--backdrop-blur);
+  -webkit-backdrop-filter: var(--backdrop-blur);
+  border: 1px solid var(--border);
+}
+
+[data-theme-style="default"][data-theme="light"] .glass {
+  background: rgba(255, 255, 255, 0.8);
+}
+
+/* Default theme: gradient text */
+[data-theme-style="default"] .gradient-text {
+  background: linear-gradient(135deg, var(--accent), #8b5cf6);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Default theme: gradient border */
+[data-theme-style="default"] .gradient-border {
+  position: relative;
+}
+
+[data-theme-style="default"] .gradient-border::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: linear-gradient(135deg, var(--accent), #8b5cf6);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
 }
 
 .error-banner {
@@ -204,6 +387,12 @@ input, textarea, select {
   border-top-color: var(--accent);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
+}
+
+/* Default theme: larger spinner */
+[data-theme-style="default"] .loading-spinner {
+  width: 40px;
+  height: 40px;
 }
 
 @keyframes spin {
@@ -248,6 +437,11 @@ input, textarea, select {
   to { opacity: 1; }
 }
 
+@keyframes pulse-glow {
+  0%, 100% { box-shadow: 0 0 20px rgba(99, 102, 241, 0.3); }
+  50% { box-shadow: 0 0 30px rgba(99, 102, 241, 0.5); }
+}
+
 .animate-fade-in-up {
   animation: fadeInUp 0.25s ease-out forwards;
 }
@@ -258,6 +452,127 @@ input, textarea, select {
 
 .animate-scale-in {
   animation: scale-in 0.2s ease-out forwards;
+}
+
+.animate-pulse-glow {
+  animation: pulse-glow 2s ease-in-out infinite;
+}
+
+/* Default theme: larger animation values */
+[data-theme-style="default"] .animate-fade-in-up {
+  animation: fadeInUp 0.4s ease-out forwards;
+}
+
+[data-theme-style="default"] .animate-slide-in {
+  animation: slideIn 0.3s ease-out forwards;
+}
+
+[data-theme-style="default"] .animate-scale-in {
+  animation: scale-in 0.25s ease-out forwards;
+}
+
+/* ═══════════════════════════════════════════════════
+   Hydro Theme  — HydroOJ 风格
+   ═══════════════════════════════════════════════════ */
+[data-theme-style="hydro"] {
+  --bg-primary: #edf0f2;
+  --bg-secondary: #ffffff;
+  --bg-tertiary: #f4f4f4;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f8f8f8;
+  --text-primary: #3d3d3d;
+  --text-secondary: #7a7a7a;
+  --text-muted: #9e9e9e;
+  --accent: #5f9fd6;
+  --accent-hover: #4a8fc9;
+  --accent-light: rgba(95, 159, 214, 0.1);
+  --accent-glow: rgba(95, 159, 214, 0.2);
+  --success: #25ad40;
+  --success-bg: rgba(37, 173, 64, 0.1);
+  --warning: #f39800;
+  --warning-bg: rgba(243, 152, 0, 0.1);
+  --error: #fb5555;
+  --error-bg: rgba(251, 85, 85, 0.1);
+  --info: #5f9fd6;
+  --info-bg: rgba(95, 159, 214, 0.1);
+  --border: #dddddd;
+  --border-light: #eeeeee;
+  --border-hover: #bbbbbb;
+  --gold: #f39800;
+  --gold-bg: rgba(243, 152, 0, 0.1);
+  --silver: #909399;
+  --silver-bg: rgba(144, 147, 153, 0.1);
+  --bronze: #cd7f32;
+  --bronze-bg: rgba(205, 127, 50, 0.1);
+  --diff-none: #aaaaaa;
+  --diff-easy: #25ad40;
+  --diff-easy-mid: #f39800;
+  --diff-mid: #f39800;
+  --diff-hard: #fb5555;
+  --diff-hard-plus: #fb5555;
+  --diff-province: #5f9fd6;
+  --diff-province-plus: #9d3dcf;
+  --diff-noi: #0e1d69;
+  --secondary-color: #ed5f82;
+  --secondary-light: rgba(237, 95, 130, 0.1);
+  --header-gradient: none;
+  --header-bg: #ffffff;
+  --radius: 0px;
+  --radius-md: 0px;
+  --radius-lg: 0px;
+  --radius-xl: 0px;
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.1);
+  --shadow-accent: none;
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.06);
+  --transition: 0.15s ease;
+  --transition-fast: 0.1s ease;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Noto Sans SC", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-mono: "SF Mono", "Fira Code", "Consolas", "Monaco", monospace;
+  --nav-item-height: 45px;
+  --nav-active-color: #ed5f82;
+}
+
+[data-theme-style="hydro"][data-theme="dark"] {
+  --bg-primary: #1a1a2e;
+  --bg-secondary: #16213e;
+  --bg-tertiary: #1e2a4a;
+  --bg-card: #16213e;
+  --bg-card-hover: #1e2a4a;
+  --text-primary: #e0e0e0;
+  --text-secondary: #a0a8b8;
+  --text-muted: #6a7288;
+  --accent: #6db3f2;
+  --accent-hover: #5a9ed9;
+  --accent-light: rgba(109, 179, 242, 0.15);
+  --accent-glow: rgba(109, 179, 242, 0.3);
+  --success: #3ddc6a;
+  --success-bg: rgba(61, 220, 106, 0.15);
+  --warning: #f5b342;
+  --warning-bg: rgba(245, 179, 66, 0.15);
+  --error: #fc7a7a;
+  --error-bg: rgba(252, 122, 122, 0.15);
+  --info: #6db3f2;
+  --info-bg: rgba(109, 179, 242, 0.15);
+  --border: #2a3a5e;
+  --border-light: #1e2a4a;
+  --border-hover: #3a4a6e;
+  --gold: #f5b342;
+  --gold-bg: rgba(245, 179, 66, 0.15);
+  --silver: #909399;
+  --silver-bg: rgba(144, 147, 153, 0.15);
+  --bronze: #cd7f32;
+  --bronze-bg: rgba(205, 127, 50, 0.15);
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.2);
+  --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 4px 16px rgba(0, 0, 0, 0.5);
+  --shadow-card: 0 1px 3px rgba(0, 0, 0, 0.3);
+  --header-bg: #16213e;
+  --secondary-color: #ed5f82;
+  --secondary-light: rgba(237, 95, 130, 0.15);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## 变更内容

### 三种 UI 主题合并为一个分支

之前 `default` 和 `luogu-style` 是两个独立分支，现在通过 `frontend/config.yaml` 中的 `site.theme` 字段即可切换：

- **`default`** — 默认风格，暗色为主，大圆角，靛蓝渐变强调色
- **`luogu`** — 洛谷风格复刻，蓝粉渐变顶栏 + 左侧边栏，9 级难度色板
- **`hydro`** — HydroOJ 风格，蓝色主调，完全扁平，极简设计

构建验证通过（TypeScript + Vite 零错误）