### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/backend/src/utils/fetch-timeout.ts
+++ b/backend/src/utils/fetch-timeout.ts
@@ -10,8 +10,13 @@ export const GITHUB_TIMEOUT_MS = 30_000;
 
 function pickTimeout(url: string | URL | Request, timeoutMs?: number): number {
   if (timeoutMs !== undefined) return timeoutMs;
-  const u = typeof url === 'string' ? url : url instanceof URL ? url.href : url.url;
-  return u.includes('api.github.com') ? GITHUB_TIMEOUT_MS : DEFAULT_TIMEOUT_MS;
+  try {
+    const parsed =
+      typeof url === 'string' ? new URL(url) : url instanceof URL ? url : new URL(url.url);
+    return parsed.hostname === 'api.github.com' ? GITHUB_TIMEOUT_MS : DEFAULT_TIMEOUT_MS;
+  } catch {
+    return DEFAULT_TIMEOUT_MS;
+  }
 }
 
 export async function fetchWithTimeout(


### PR DESCRIPTION
Potential fix for [https://github.com/wanwusangzhigit/eoj/security/code-scanning/8](https://github.com/wanwusangzhigit/eoj/security/code-scanning/8)

General fix: parse the input into a URL object, extract `hostname`, and compare that value explicitly instead of using substring matching on the full URL string.

Best minimal fix (without changing existing functionality intent):
- In `backend/src/utils/fetch-timeout.ts`, update `pickTimeout` so it:
  - Normalizes `url` (`string | URL | Request`) into a URL instance.
  - Safely handles parse failures by falling back to `DEFAULT_TIMEOUT_MS`.
  - Applies GitHub timeout only when `hostname` is exactly `api.github.com`.
- No new imports or dependencies are required; `URL` is already globally available in Worker/Fetch environments.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
