### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -232,7 +232,14 @@ auth.get('/cpoauth/callback', async (c) => {
 
     tokenData = (await tokenResponse.json()) as { access_token?: string; error?: string; error_description?: string; statusMessage?: string; message?: string };
     if (!tokenData.access_token) {
-      console.error('CP OAuth token error (redirect_uri used):', redirectUri, 'body sent:', JSON.stringify(tokenBody), 'server response:', JSON.stringify(tokenData));
+      const sanitizedTokenBody = {
+        ...tokenBody,
+        client_id: '[REDACTED]',
+        client_secret: '[REDACTED]',
+        code: tokenBody.code ? '[REDACTED]' : undefined,
+        code_verifier: tokenBody.code_verifier ? '[REDACTED]' : undefined,
+      };
+      console.error('CP OAuth token error (redirect_uri used):', redirectUri, 'body sent:', JSON.stringify(sanitizedTokenBody), 'server response:', JSON.stringify(tokenData));
       const detail = tokenData.message || tokenData.error_description || tokenData.statusMessage || String(tokenData.error || 'unknown');
       return c.redirect(`${returnOrigin}/auth/callback?error=token_failed&detail=${encodeURIComponent(detail)}`);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/wanwusangzhigit/eoj/security/code-scanning/9](https://github.com/wanwusangzhigit/eoj/security/code-scanning/9)

Best practice is to never log raw OAuth credentials or tokens. Keep operational context (like redirect URI and provider error payload), but sanitize request payloads before logging.

In `backend/src/routes/auth.ts`, update the error log at line 235 so it does **not** print `JSON.stringify(tokenBody)` directly. Instead, log a redacted copy where sensitive fields are masked (at minimum `client_id`, `client_secret`, and preferably `code` and `code_verifier` too). This preserves troubleshooting value without exposing credentials.

No new imports or dependencies are required. A local constant for the sanitized object right before `console.error` is sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
